### PR TITLE
add dependency for modelscope

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "pydantic",
     "pillow",
     "huggingface_hub",
+    "modelscope",
     "prompt_toolkit",
     "tqdm",                     # Shared dependencies
     "tabulate",


### PR DESCRIPTION
We find that the latested prebuilt whl or Executable Installer do not contain the modelscope module.
To import modelscope, I add the `modelscope` dependency in the pyproject.toml and I guess this may install the modelscope module when building `nexaai`. If there are any other places where the modelscope dependencies need to be added, please let me know. And thank you for updating the whl and Executable Installer to the version that support model downloading from ModelScope.