### PR TITLE
Deferred outetts loading to fix incorrect torchaudio dependency.

### DIFF
--- a/nexa/gguf/nexa_inference_tts.py
+++ b/nexa/gguf/nexa_inference_tts.py
@@ -10,7 +10,6 @@ from nexa.general import pull_model
 from nexa.gguf.lib_utils import is_gpu_available
 
 from nexa.gguf.bark import bark_cpp
-import nexa.gguf.outetts as outetts
 
 class NexaTTSInference:
     """
@@ -143,7 +142,7 @@ class NexaTTSInference:
             # OuteTTS loading
             logging.debug(f"Loading OuteTTS model from {self.downloaded_path}")
             # For OuteTTS we assume model_path is a GGUF model.
-            # Example from run_outetts.py:
+            import nexa.gguf.outetts as outetts
             model_config = outetts.GGUFModelConfig_v1(
                 model_path=self.downloaded_path,
                 language=self.language,


### PR DESCRIPTION
Fixed an incorrect dependency on `torchaudio` when running non-OuteTTS models.