### PR TITLE
Switch build platform from QEMU to GitHub-hosted ARM64 Ubuntu to fix wheel build issues in build_wheels_arm64

### DIFF
--- a/.github/workflows/build-wheels-cpu.yaml
+++ b/.github/workflows/build-wheels-cpu.yaml
@@ -100,6 +100,9 @@ jobs:
         with:
           submodules: "recursive"
 
+      - name: Check nproc value
+        run: echo "Number of processors: $(nproc)"
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
         with:
@@ -113,7 +116,7 @@ jobs:
           CIBW_SKIP: "*musllinux* pp*"
           CIBW_ARCHS: "aarch64"
           CIBW_BUILD: "cp37-* cp38-* cp39-* cp310-* cp311-* cp312-* cp313-*"
-          CMAKE_BUILD_PARALLEL_LEVEL: $(nproc)
+          CMAKE_BUILD_PARALLEL_LEVEL: 4
         with:
           output-dir: wheelhouse
 

--- a/.github/workflows/build-wheels-cpu.yaml
+++ b/.github/workflows/build-wheels-cpu.yaml
@@ -48,49 +48,49 @@ jobs:
   #         name: wheels-${{ matrix.os }}
   #         path: ./wheelhouse/*.whl
 
-  build_wheels_win:
-    name: Build wheels on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        # here 'sdk-windows-8-core' is a large runner
-        os: [sdk-windows-8-core]
+  # build_wheels_win:
+  #   name: Build wheels on ${{ matrix.os }}
+  #   runs-on: ${{ matrix.os }}
+  #   strategy:
+  #     matrix:
+  #       # here 'sdk-windows-8-core' is a large runner
+  #       os: [sdk-windows-8-core]
 
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: "recursive"
-      - uses: GuillaumeFalourd/setup-windows10-sdk-action@v2
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #       with:
+  #         submodules: "recursive"
+  #     - uses: GuillaumeFalourd/setup-windows10-sdk-action@v2
 
-      # Used to host cibuildwheel
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.8"
-          cache: "pip"
+  #     # Used to host cibuildwheel
+  #     - uses: actions/setup-python@v5
+  #       with:
+  #         python-version: "3.8"
+  #         cache: "pip"
 
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          # python -m pip install -e .
-          python -m pip install build wheel
+  #     - name: Install dependencies
+  #       run: |
+  #         python -m pip install --upgrade pip
+  #         # python -m pip install -e .
+  #         python -m pip install build wheel
 
-      - name: Build wheels
-        uses: pypa/cibuildwheel@v2.20.0
-        env:
-          # disable repair
-          CIBW_REPAIR_WHEEL_COMMAND: ""
-          CIBW_BUILD_FRONTEND: "build"
-          CIBW_BUILD: "cp37-* cp38-* cp39-* cp310-* cp311-* cp312-* cp313-*"
-          CMAKE_BUILD_PARALLEL_LEVEL: 16
-          CIBW_ENVIRONMENT_WINDOWS: 'CMAKE_ARGS="-DCMAKE_SYSTEM_VERSION=10.0.18362.0 -DCMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION=10.0.18362.0"'
-        with:
-          package-dir: .
-          output-dir: wheelhouse
+  #     - name: Build wheels
+  #       uses: pypa/cibuildwheel@v2.20.0
+  #       env:
+  #         # disable repair
+  #         CIBW_REPAIR_WHEEL_COMMAND: ""
+  #         CIBW_BUILD_FRONTEND: "build"
+  #         CIBW_BUILD: "cp37-* cp38-* cp39-* cp310-* cp311-* cp312-* cp313-*"
+  #         CMAKE_BUILD_PARALLEL_LEVEL: 16
+  #         CIBW_ENVIRONMENT_WINDOWS: 'CMAKE_ARGS="-DCMAKE_SYSTEM_VERSION=10.0.18362.0 -DCMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION=10.0.18362.0"'
+  #       with:
+  #         package-dir: .
+  #         output-dir: wheelhouse
 
-      - uses: actions/upload-artifact@v4
-        with:
-          name: wheels-${{ matrix.os }}
-          path: ./wheelhouse/*.whl
+  #     - uses: actions/upload-artifact@v4
+  #       with:
+  #         name: wheels-${{ matrix.os }}
+  #         path: ./wheelhouse/*.whl
 
   build_wheels_arm64:
     name: Build arm64 wheels

--- a/.github/workflows/build-wheels-cpu.yaml
+++ b/.github/workflows/build-wheels-cpu.yaml
@@ -94,19 +94,19 @@ jobs:
 
   build_wheels_arm64:
     name: Build arm64 wheels
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-20.04-arm
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: "recursive"    
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: linux/arm64
+      # - name: Set up QEMU
+      #   uses: docker/setup-qemu-action@v3
+      #   with:
+      #     platforms: linux/arm64
 
-      - name: Check nproc value
-        run: echo "Number of processors $(nproc)"
+      # - name: Check nproc value
+      #   run: echo "Number of processors $(nproc)"
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.20.0

--- a/.github/workflows/build-wheels-cpu.yaml
+++ b/.github/workflows/build-wheels-cpu.yaml
@@ -106,7 +106,7 @@ jobs:
           platforms: linux/arm64
 
       - name: Check nproc value
-        run: echo "Number of processors: $(nproc)"
+        run: echo "Number of processors $(nproc)"
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.20.0

--- a/.github/workflows/build-wheels-cpu.yaml
+++ b/.github/workflows/build-wheels-cpu.yaml
@@ -94,7 +94,7 @@ jobs:
 
   build_wheels_arm64:
     name: Build arm64 wheels
-    runs-on: ubuntu-20.04-arm
+    runs-on: ubuntu-22.04-arm
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/build-wheels-cpu.yaml
+++ b/.github/workflows/build-wheels-cpu.yaml
@@ -98,15 +98,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          submodules: "recursive"
-
-      - name: Check nproc value
-        run: echo "Number of processors: $(nproc)"
+          submodules: "recursive"    
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
         with:
           platforms: linux/arm64
+
+      - name: Check nproc value
+        run: echo "Number of processors: $(nproc)"
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.20.0

--- a/.github/workflows/build-wheels-cpu.yaml
+++ b/.github/workflows/build-wheels-cpu.yaml
@@ -126,43 +126,43 @@ jobs:
           name: wheels_arm64
           path: ./wheelhouse/*.whl
 
-  build_sdist:
-    name: Build source distribution
-    runs-on: ubuntu-latest
+  # build_sdist:
+  #   name: Build source distribution
+  #   runs-on: ubuntu-latest
 
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: "recursive"
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.8"
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip build
-          python -m pip install -e .
-      - name: Build source distribution
-        run: |
-          python -m build --sdist
-      - uses: actions/upload-artifact@v4
-        with:
-          name: sdist
-          path: ./dist/*.tar.gz
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #       with:
+  #         submodules: "recursive"
+  #     - uses: actions/setup-python@v5
+  #       with:
+  #         python-version: "3.8"
+  #     - name: Install dependencies
+  #       run: |
+  #         python -m pip install --upgrade pip build
+  #         python -m pip install -e .
+  #     - name: Build source distribution
+  #       run: |
+  #         python -m build --sdist
+  #     - uses: actions/upload-artifact@v4
+  #       with:
+  #         name: sdist
+  #         path: ./dist/*.tar.gz
 
-  release:
-    name: Release
-    needs: [build_wheels_win, build_wheels_arm64, build_sdist]  # build_wheels_linux
-    runs-on: ubuntu-latest
+  # release:
+  #   name: Release
+  #   needs: [build_wheels_win, build_wheels_arm64, build_sdist]  # build_wheels_linux
+  #   runs-on: ubuntu-latest
 
-    steps:
-      - uses: actions/download-artifact@v4
-        with:
-          merge-multiple: true
-          path: dist
+  #   steps:
+  #     - uses: actions/download-artifact@v4
+  #       with:
+  #         merge-multiple: true
+  #         path: dist
 
-      - uses: softprops/action-gh-release@v2
-        with:
-          files: dist/*
-          tag_name: ${{ github.ref_name }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #     - uses: softprops/action-gh-release@v2
+  #       with:
+  #         files: dist/*
+  #         tag_name: ${{ github.ref_name }}
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-wheels-cpu.yaml
+++ b/.github/workflows/build-wheels-cpu.yaml
@@ -48,49 +48,49 @@ jobs:
   #         name: wheels-${{ matrix.os }}
   #         path: ./wheelhouse/*.whl
 
-  # build_wheels_win:
-  #   name: Build wheels on ${{ matrix.os }}
-  #   runs-on: ${{ matrix.os }}
-  #   strategy:
-  #     matrix:
-  #       # here 'sdk-windows-8-core' is a large runner
-  #       os: [sdk-windows-8-core]
+  build_wheels_win:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        # here 'sdk-windows-8-core' is a large runner
+        os: [sdk-windows-8-core]
 
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #       with:
-  #         submodules: "recursive"
-  #     - uses: GuillaumeFalourd/setup-windows10-sdk-action@v2
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: "recursive"
+      - uses: GuillaumeFalourd/setup-windows10-sdk-action@v2
 
-  #     # Used to host cibuildwheel
-  #     - uses: actions/setup-python@v5
-  #       with:
-  #         python-version: "3.8"
-  #         cache: "pip"
+      # Used to host cibuildwheel
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.8"
+          cache: "pip"
 
-  #     - name: Install dependencies
-  #       run: |
-  #         python -m pip install --upgrade pip
-  #         # python -m pip install -e .
-  #         python -m pip install build wheel
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          # python -m pip install -e .
+          python -m pip install build wheel
 
-  #     - name: Build wheels
-  #       uses: pypa/cibuildwheel@v2.20.0
-  #       env:
-  #         # disable repair
-  #         CIBW_REPAIR_WHEEL_COMMAND: ""
-  #         CIBW_BUILD_FRONTEND: "build"
-  #         CIBW_BUILD: "cp37-* cp38-* cp39-* cp310-* cp311-* cp312-* cp313-*"
-  #         CMAKE_BUILD_PARALLEL_LEVEL: 16
-  #         CIBW_ENVIRONMENT_WINDOWS: 'CMAKE_ARGS="-DCMAKE_SYSTEM_VERSION=10.0.18362.0 -DCMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION=10.0.18362.0"'
-  #       with:
-  #         package-dir: .
-  #         output-dir: wheelhouse
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.20.0
+        env:
+          # disable repair
+          CIBW_REPAIR_WHEEL_COMMAND: ""
+          CIBW_BUILD_FRONTEND: "build"
+          CIBW_BUILD: "cp37-* cp38-* cp39-* cp310-* cp311-* cp312-* cp313-*"
+          CMAKE_BUILD_PARALLEL_LEVEL: 16
+          CIBW_ENVIRONMENT_WINDOWS: 'CMAKE_ARGS="-DCMAKE_SYSTEM_VERSION=10.0.18362.0 -DCMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION=10.0.18362.0"'
+        with:
+          package-dir: .
+          output-dir: wheelhouse
 
-  #     - uses: actions/upload-artifact@v4
-  #       with:
-  #         name: wheels-${{ matrix.os }}
-  #         path: ./wheelhouse/*.whl
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheels-${{ matrix.os }}
+          path: ./wheelhouse/*.whl
 
   build_wheels_arm64:
     name: Build arm64 wheels
@@ -126,43 +126,43 @@ jobs:
           name: wheels_arm64
           path: ./wheelhouse/*.whl
 
-  # build_sdist:
-  #   name: Build source distribution
-  #   runs-on: ubuntu-latest
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
 
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #       with:
-  #         submodules: "recursive"
-  #     - uses: actions/setup-python@v5
-  #       with:
-  #         python-version: "3.8"
-  #     - name: Install dependencies
-  #       run: |
-  #         python -m pip install --upgrade pip build
-  #         python -m pip install -e .
-  #     - name: Build source distribution
-  #       run: |
-  #         python -m build --sdist
-  #     - uses: actions/upload-artifact@v4
-  #       with:
-  #         name: sdist
-  #         path: ./dist/*.tar.gz
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: "recursive"
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.8"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip build
+          python -m pip install -e .
+      - name: Build source distribution
+        run: |
+          python -m build --sdist
+      - uses: actions/upload-artifact@v4
+        with:
+          name: sdist
+          path: ./dist/*.tar.gz
 
-  # release:
-  #   name: Release
-  #   needs: [build_wheels_win, build_wheels_arm64, build_sdist]  # build_wheels_linux
-  #   runs-on: ubuntu-latest
+  release:
+    name: Release
+    needs: [build_wheels_win, build_wheels_arm64, build_sdist]  # build_wheels_linux
+    runs-on: ubuntu-latest
 
-  #   steps:
-  #     - uses: actions/download-artifact@v4
-  #       with:
-  #         merge-multiple: true
-  #         path: dist
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          merge-multiple: true
+          path: dist
 
-  #     - uses: softprops/action-gh-release@v2
-  #       with:
-  #         files: dist/*
-  #         tag_name: ${{ github.ref_name }}
-  #       env:
-  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*
+          tag_name: ${{ github.ref_name }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-wheels-cpu.yaml
+++ b/.github/workflows/build-wheels-cpu.yaml
@@ -98,7 +98,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          submodules: "recursive"    
+          submodules: "recursive"
 
       # - name: Set up QEMU
       #   uses: docker/setup-qemu-action@v3
@@ -116,7 +116,7 @@ jobs:
           CIBW_SKIP: "*musllinux* pp*"
           CIBW_ARCHS: "aarch64"
           CIBW_BUILD: "cp37-* cp38-* cp39-* cp310-* cp311-* cp312-* cp313-*"
-          CMAKE_BUILD_PARALLEL_LEVEL: 4
+          CMAKE_BUILD_PARALLEL_LEVEL: $(nproc)
         with:
           output-dir: wheelhouse
 


### PR DESCRIPTION
**Description**
This PR updates the ARM64 build platform from QEMU to GitHub-hosted ARM64 Ubuntu runners. The QEMU-based environment is unstable and causes frequent build failures. Switching to official ARM64 resolves this issue.