### PR TITLE
use https for server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,6 @@ tmp/
 
 # Delve debugger
 __debug_bin
+
+# TLS certificates
+*.pem

--- a/runner/cmd/nexa-cli/serve.go
+++ b/runner/cmd/nexa-cli/serve.go
@@ -1,12 +1,9 @@
 package main
 
 import (
-	"log/slog"
-
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	"github.com/NexaAI/nexa-sdk/internal/config"
 	nexa_sdk "github.com/NexaAI/nexa-sdk/nexa-sdk"
 	"github.com/NexaAI/nexa-sdk/server"
 )
@@ -22,7 +19,6 @@ func serve() *cobra.Command {
 	serveCmd.Short = "Run the Nexa AI Service"
 
 	serveCmd.Run = func(cmd *cobra.Command, args []string) {
-		slog.Info("Start Nexa AI Server on http://" + config.Get().Host)
 
 		// Initialize SDK resources and prepare AI models for serving
 		nexa_sdk.Init()
@@ -38,9 +34,16 @@ func serve() *cobra.Command {
 	serveCmd.Flags().SortFlags = false
 	serveCmd.Flags().String("host", "127.0.0.1:18181", "Default server address (env: NEXA_HOST)")
 	serveCmd.Flags().Int("keepalive", 300, "Keepalive seconds (env: NEXA_KEEPALIVE)")
+	// HTTPS / TLS flags
+	serveCmd.Flags().Bool("https", false, "Enable HTTPS/TLS (env: NEXA_ENABLEHTTPS)")
+	serveCmd.Flags().String("certfile", "cert.pem", "TLS certificate file path (env: NEXA_CERTFILE)")
+	serveCmd.Flags().String("keyfile", "key.pem", "TLS private key file path (env: NEXA_KEYFILE)")
 
 	viper.BindPFlag("host", serveCmd.Flags().Lookup("host"))
 	viper.BindPFlag("keepalive", serveCmd.Flags().Lookup("keepalive"))
+	viper.BindPFlag("enablehttps", serveCmd.Flags().Lookup("https"))
+	viper.BindPFlag("certfile", serveCmd.Flags().Lookup("certfile"))
+	viper.BindPFlag("keyfile", serveCmd.Flags().Lookup("keyfile"))
 
 	return serveCmd
 }

--- a/runner/internal/config/config.go
+++ b/runner/internal/config/config.go
@@ -12,6 +12,11 @@ type Config struct {
 	HFToken   string
 
 	Log string // Enable backend log
+
+	// HTTPS / TLS settings
+	EnableHTTPS bool   // Whether to serve over HTTPS (default: false)
+	CertFile    string // TLS certificate file path
+	KeyFile     string // TLS private key file path
 }
 
 var config *Config
@@ -32,6 +37,11 @@ func init() {
 	viper.SetDefault("hftoken", "")             // Default empty token
 
 	viper.SetDefault("log", "info") // Default log level
+
+	// HTTPS defaults - disabled unless explicitly enabled
+	viper.SetDefault("enablehttps", false)
+	viper.SetDefault("certfile", "cert.pem")
+	viper.SetDefault("keyfile", "key.pem")
 }
 
 // get initializes the configuration by reading from environment variables.

--- a/runner/server/docs/swagger.yaml
+++ b/runner/server/docs/swagger.yaml
@@ -4,9 +4,6 @@ info:
   version: 0.0.0
   description: |
     Nexa AI Server - OpenAI compatible API endpoints
-servers:
-  - url: http://127.0.0.1:18181
-    description: Local dev server
 
 paths:
   /v1/completions:

--- a/runner/server/server.go
+++ b/runner/server/server.go
@@ -42,10 +42,10 @@ func Serve() {
 		}
 
 		slog.Info("HTTPS enabled", "cert", certFile, "key", keyFile)
-		slog.Info("Localhosted documentation on https://" + cfg.Host + "/docs/ui")
+		// slog.Info("Localhosting on https://" + cfg.Host + "/docs/ui")
 		err = engine.RunTLS(cfg.Host, certFile, keyFile)
 	} else {
-		slog.Info("Localhosted documentation on http://" + cfg.Host + "/docs/ui")
+		slog.Info("Localhosting on http://" + cfg.Host + "/docs/ui")
 		err = engine.Run(cfg.Host)
 	}
 

--- a/ssl/README.md
+++ b/ssl/README.md
@@ -1,0 +1,5 @@
+### Usage
+
+1. start from project root
+2. Set CF_Token and CF_Zone_ID in shell variable
+3. ssl/httpsserve.sh <subdomain>, e.g. `ssl/httpsserve.sh leo`

--- a/ssl/httpsserve.sh
+++ b/ssl/httpsserve.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+#--------------- configuration ------------------------------------------------
+SUBDOMAIN="${1:-anonymoususer}"
+FULLDOMAIN="${SUBDOMAIN}.nexasdk.com"
+API="https://api.cloudflare.com/client/v4"
+HEADER_AUTH="Authorization: Bearer ${CF_Token:?need CF_Token}"
+HEADER_JSON="Content-Type: application/json"
+TTL=60
+
+#--------------- locate / install acme.sh ------------------------------------
+ACME="$HOME/acme.sh/acme.sh"
+if [[ ! -x "$ACME" ]]; then
+  echo "acme.sh not found – installing…" >&2
+  curl -fsSL https://get.acme.sh | sh >/dev/null 2>&1
+  ACME="$HOME/.acme.sh/acme.sh"
+  echo "acme.sh installed to $ACME" >&2
+fi
+
+# Abort if still not executable
+[[ -x "$ACME" ]] || { echo "Failed to install acme.sh" >&2; exit 1; }
+
+#--------------- determine private IP ----------------------------------------
+PRIVATE_IP=$(ipconfig getifaddr en0 2>/dev/null || ipconfig getifaddr en1)
+if [[ -z "$PRIVATE_IP" ]]; then
+  echo "Could not determine private IP address" >&2
+  exit 1
+fi
+
+#--------------- cleanup ------------------------------------------------------
+cleanup() {
+  lookup=$(curl -sS "$API/zones/$CF_Zone_ID/dns_records?type=A&name=$FULLDOMAIN" -H "$HEADER_AUTH")
+  rid=$(jq -r '.result[0].id // empty' <<<"$lookup")
+
+  if [[ -z "$rid" ]]; then
+    echo "$FULLDOMAIN is already clean."
+  else
+    curl -sS -X DELETE "$API/zones/$CF_Zone_ID/dns_records/$rid" -H "$HEADER_AUTH" >/dev/null \
+      && echo "$FULLDOMAIN is cleaned up."
+  fi
+}
+cleanup
+trap cleanup EXIT
+
+#--------------- create DNS record -------------------------------------------
+printf "Creating DNS record %s → %s\n" "$FULLDOMAIN" "$PRIVATE_IP"
+create_resp=$(
+  curl -sS -X POST "$API/zones/$CF_Zone_ID/dns_records" \
+       -H "$HEADER_AUTH" -H "$HEADER_JSON" \
+       --data '{"type":"A","name":"'$SUBDOMAIN'","content":"'$PRIVATE_IP'","ttl":'$TTL',"proxied":false}'
+)
+record_id=$(jq -r '.result.id // empty' <<<"$create_resp")
+if [[ -z "$record_id" ]]; then
+  echo "Failed to create record:" >&2
+  jq -r '.errors[]?.message' <<<"$create_resp" >&2 || echo "$create_resp" >&2
+  exit 1
+fi
+printf "Record created (id=%s)\n" "$record_id"s
+
+
+#--------------- generate certificate ----------------------------------------
+# Ensure ssl directory exists
+mkdir -p ssl
+"$ACME" --server letsencrypt --issue --dns dns_cf -d "$FULLDOMAIN" --force
+"$ACME" --install-cert -d "$FULLDOMAIN" --key-file ssl/key.pem --cert-file ssl/cert.pem --force
+
+#--------------- run server ---------------------------------------------------
+echo "Serving at: https://$FULLDOMAIN:18181/docs/ui"
+./build/nexa serve --host=0.0.0.0:18181 --https --certfile ssl/cert.pem --keyfile ssl/key.pem


### PR DESCRIPTION
https://github.com/NexaAI/nexa-sdk/blob/leo/https/ssl/README.md

```sh
(base) [1m5.551s][255][leo/https][~/Documents/nexa/nexa-sdk]$ ssl/httpsserve.sh leo12
leo12.nexasdk.com is already clean.
Creating DNS record leo12.nexasdk.com → 192.168.1.132
Record created (id=058acdbcf3ddf7f83d39701a3eab3602s)
[Tue Jul 29 15:23:42 PDT 2025] Using CA: https://acme-v02.api.letsencrypt.org/directory
[Tue Jul 29 15:23:42 PDT 2025] Single domain='leo12.nexasdk.com'
[Tue Jul 29 15:23:42 PDT 2025] Getting webroot for domain='leo12.nexasdk.com'
[Tue Jul 29 15:23:43 PDT 2025] leo12.nexasdk.com is already verified, skipping dns-01.
[Tue Jul 29 15:23:43 PDT 2025] Verification finished, beginning signing.
[Tue Jul 29 15:23:43 PDT 2025] Let's finalize the order.
[Tue Jul 29 15:23:43 PDT 2025] Le_OrderFinalize='https://acme-v02.api.letsencrypt.org/acme/finalize/2561572501/412312985041'
[Tue Jul 29 15:23:45 PDT 2025] Downloading cert.
[Tue Jul 29 15:23:45 PDT 2025] Le_LinkCert='https://acme-v02.api.letsencrypt.org/acme/cert/06366652439529d49ccf60fd2c03cb18a3c0'
[Tue Jul 29 15:23:45 PDT 2025] Cert success.
-----BEGIN CERTIFICATE-----
MIIDjjCCAxOgAwIBAgISBjZmUkOVKdScz2D9LAPLGKPAMAoGCCqGSM49BAMDMDIx
CzAJBgNVBAYTAlVTMRYwFAYDVQQKEw1MZXQncyBFbmNyeXB0MQswCQYDVQQDEwJF
NjAeFw0yNTA3MjkyMTI1MTNaFw0yNTEwMjcyMTI1MTJaMBwxGjAYBgNVBAMTEWxl
bzEyLm5leGFzZGsuY29tMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEwM2lq/6i
+ZZaT5s0jDDU1PRX/yvbpGCjsA06QXdDEqI7Wy8m+QAJdt2pFjGtUAEWP73RJgXh
dty2QOn5XHfq3qOCAh0wggIZMA4GA1UdDwEB/wQEAwIHgDAdBgNVHSUEFjAUBggr
BgEFBQcDAQYIKwYBBQUHAwIwDAYDVR0TAQH/BAIwADAdBgNVHQ4EFgQU79WzB9zo
e7WWrJBdX/ZqaY61kOQwHwYDVR0jBBgwFoAUkydGmAOpUWiOmNbEQkjbI79YlNIw
MgYIKwYBBQUHAQEEJjAkMCIGCCsGAQUFBzAChhZodHRwOi8vZTYuaS5sZW5jci5v
cmcvMBwGA1UdEQQVMBOCEWxlbzEyLm5leGFzZGsuY29tMBMGA1UdIAQMMAowCAYG
Z4EMAQIBMC0GA1UdHwQmMCQwIqAgoB6GHGh0dHA6Ly9lNi5jLmxlbmNyLm9yZy82
NS5jcmwwggECBgorBgEEAdZ5AgQCBIHzBIHwAO4AdQCkQsUGSWBhVI8P1Oqc+3ot
JkVNh6l/L99FWfYnTzqEVAAAAZhYSM7QAAAEAwBGMEQCICj55E7tvXkUxX2GJzhf
OLwIIhy8qIlCIJIRCRwRlRhEAiAv4Xfmr9dK36ihSjlTC2ksk1JHeErhE3IGo/Xw
06dwBgB1AN3cyjSV1+EWBeeVMvrHn/g9HFDf2wA6FBJ2Ciysu8gqAAABmFhI1uEA
AAQDAEYwRAIgeB8wsAJkstLpro1mhUV6AsvVAJcN1Y1emm9dkD9ZrhUCIHkHQhYp
2LIODB1KN0M2K6P0RR4Hatd3T7OIrDC2idp0MAoGCCqGSM49BAMDA2kAMGYCMQDV
FpbfSKUr6ms0iLoqnbVM5va+KVwviC0642F+E7wlNRSNRrC6Br572AM57h66DkQC
MQCdzOJlJsGkdwDdVrWwIdYoWPnwi5ahC9Es07muOCkaWPLJ0xC/QtwFrMaIuq85
7yY=
-----END CERTIFICATE-----
[Tue Jul 29 15:23:45 PDT 2025] Your cert is in: /Users/wlt/.acme.sh/leo12.nexasdk.com_ecc/leo12.nexasdk.com.cer
[Tue Jul 29 15:23:45 PDT 2025] Your cert key is in: /Users/wlt/.acme.sh/leo12.nexasdk.com_ecc/leo12.nexasdk.com.key
[Tue Jul 29 15:23:45 PDT 2025] The intermediate CA cert is in: /Users/wlt/.acme.sh/leo12.nexasdk.com_ecc/ca.cer
[Tue Jul 29 15:23:45 PDT 2025] And the full-chain cert is in: /Users/wlt/.acme.sh/leo12.nexasdk.com_ecc/fullchain.cer
[Tue Jul 29 15:23:46 PDT 2025] The domain 'leo12.nexasdk.com' seems to already have an ECC cert, let's use it.
[Tue Jul 29 15:23:46 PDT 2025] Installing cert to: ssl/cert.pem
[Tue Jul 29 15:23:46 PDT 2025] Installing key to: ssl/key.pem
Serving at: https://leo12.nexasdk.com:18181/docs/ui
2025/07/29 15:23:46 INFO HTTPS enabled cert=ssl/cert.pem key=ssl/key.pem
[GIN] 2025/07/29 - 15:23:47 | 200 |    6.323667ms |   192.168.1.183 | GET      "/docs/ui/"
[GIN] 2025/07/29 - 15:23:47 | 200 |      41.583µs |   192.168.1.183 | GET      "/docs/ui/index.css"
[GIN] 2025/07/29 - 15:23:47 | 200 |       24.75µs |   192.168.1.183 | GET      "/docs/ui/swagger-initializer.js"
[GIN] 2025/07/29 - 15:23:47 | 200 |   43.630209ms |   192.168.1.183 | GET      "/docs/ui/swagger-ui.css"
[GIN] 2025/07/29 - 15:23:47 | 200 |    44.99025ms |   192.168.1.183 | GET      "/docs/ui/swagger-ui-standalone-preset.js"
[GIN] 2025/07/29 - 15:23:47 | 200 |      80.744ms |   192.168.1.183 | GET      "/docs/ui/swagger-ui-bundle.js"
[GIN] 2025/07/29 - 15:23:48 | 200 |    1.892417ms |   192.168.1.183 | GET      "/docs/swagger.yaml"
[GIN] 2025/07/29 - 15:23:48 | 200 |      64.209µs |   192.168.1.183 | GET      "/docs/ui/favicon-16x16.png"
[GIN] 2025/07/29 - 15:23:48 | 200 |      66.542µs |   192.168.1.183 | GET      "/docs/ui/favicon-32x32.png"
^Cleo12.nexasdk.com is cleaned up.
```

<img width="1170" height="2532" alt="IMG_2742" src="https://github.com/user-attachments/assets/e05e88d3-8cba-4e02-9041-1ef296058172" />