### PR TITLE
feat : update nexa list print

### DIFF
--- a/runner/cmd/nexa-cli/model.go
+++ b/runner/cmd/nexa-cli/model.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/dustin/go-humanize"
 	"github.com/jedib0t/go-pretty/v6/table"
@@ -173,15 +172,9 @@ func list() *cobra.Command {
 		tw := table.NewWriter()
 		tw.SetOutputMirror(os.Stdout)
 		tw.SetStyle(table.StyleLight)
-		tw.AppendHeader(table.Row{"NAME", "TYPE", "PLUGIN", "QUANT", "SIZE"})
+		tw.AppendHeader(table.Row{"NAME", "SIZE"})
 		for _, model := range models {
-			var quants []string
-			for k := range model.ModelFile {
-				if model.ModelFile[k].Downloaded {
-					quants = append(quants, k)
-				}
-			}
-			tw.AppendRow(table.Row{model.Name, model.ModelType, model.PluginId, strings.Join(quants, ","), humanize.IBytes(uint64(model.GetSize()))})
+			tw.AppendRow(table.Row{model.Name, humanize.IBytes(uint64(model.GetSize()))})
 		}
 		tw.Render()
 	}


### PR DESCRIPTION
This pull request simplifies the output of the model listing command in `runner/cmd/nexa-cli/model.go` by reducing the displayed columns to only the model name and size, making the output clearer and more focused.

Improvements to CLI output:

* The table header in the list command was changed to display only "NAME" and "SIZE", removing columns for type, plugin, and quantization. (`runner/cmd/nexa-cli/model.go`)
* The row data was updated to match the new header, showing just the model name and its human-readable size. (`runner/cmd/nexa-cli/model.go`)

Code cleanup:

* The unused import of the `strings` package was removed, since quantization details are no longer displayed. (`runner/cmd/nexa-cli/model.go`)