### PR TITLE
feat: add system prompt and pass prompt.txt for LLM/VLM

### DIFF
--- a/runner/nexa-sdk/common.go
+++ b/runner/nexa-sdk/common.go
@@ -260,6 +260,7 @@ type ModelConfig struct {
 	NGpuLayers          int32
 	ChatTemplatePath    string
 	ChatTemplateContent string
+	SystemPrompt        string
 }
 
 // TODO: check this if it's needed, llm has it self.

--- a/runner/nexa-sdk/llm.go
+++ b/runner/nexa-sdk/llm.go
@@ -68,6 +68,10 @@ func (lci LlmCreateInput) toCPtr() *C.ml_LlmCreateInput {
 	if lci.Config.ChatTemplateContent != "" {
 		cPtr.config.chat_template_content = C.CString(lci.Config.ChatTemplateContent)
 	}
+	// Add system prompt support
+	if lci.Config.SystemPrompt != "" {
+		cPtr.config.system_prompt = C.CString(lci.Config.SystemPrompt)
+	}
 
 	return cPtr
 }
@@ -95,6 +99,9 @@ func freeLlmCreateInput(cPtr *C.ml_LlmCreateInput) {
 		}
 		if cPtr.config.chat_template_content != nil {
 			C.free(unsafe.Pointer(cPtr.config.chat_template_content))
+		}
+		if cPtr.config.system_prompt != nil {
+			C.free(unsafe.Pointer(cPtr.config.system_prompt))
 		}
 
 		// Free the main structure

--- a/runner/nexa-sdk/vlm.go
+++ b/runner/nexa-sdk/vlm.go
@@ -62,6 +62,10 @@ func (vci VlmCreateInput) toCPtr() *C.ml_VlmCreateInput {
 	if vci.Config.ChatTemplateContent != "" {
 		cPtr.config.chat_template_content = C.CString(vci.Config.ChatTemplateContent)
 	}
+	// Add system prompt support
+	if vci.Config.SystemPrompt != "" {
+		cPtr.config.system_prompt = C.CString(vci.Config.SystemPrompt)
+	}
 
 	return cPtr
 }
@@ -91,6 +95,9 @@ func freeVlmCreateInput(cPtr *C.ml_VlmCreateInput) {
 		}
 		if cPtr.config.chat_template_content != nil {
 			C.free(unsafe.Pointer(cPtr.config.chat_template_content))
+		}
+		if cPtr.config.system_prompt != nil {
+			C.free(unsafe.Pointer(cPtr.config.system_prompt))
 		}
 
 		// Free the main structure


### PR DESCRIPTION
This pull request adds support for specifying a "system prompt" in both the LLM and VLM inference commands in `nexa-cli`. The system prompt allows users to influence the model's behavior at runtime. The changes include new CLI flags, updates to the configuration structures, and proper handling of the system prompt in memory management and prompt processing.

**System Prompt Support**

* Added a `--system-prompt` (`-s`) flag to the `infer` CLI command, allowing users to specify a system prompt for LLM and VLM models. (`runner/cmd/nexa-cli/infer.go` [[1]](diffhunk://#diff-80e517e48dd824f85f30788bc28f60809fbadc82896404db3263a72f5b2c5883R46) [[2]](diffhunk://#diff-80e517e48dd824f85f30788bc28f60809fbadc82896404db3263a72f5b2c5883R69)
* Updated the `ModelConfig` struct to include a new `SystemPrompt` field, which is passed to the model during initialization. (`runner/nexa-sdk/common.go` [runner/nexa-sdk/common.goR263](diffhunk://#diff-7d0d4a35d657693689abb0afc6663997d46981339f56369d19f753a4608063f7R263))
* Modified the LLM and VLM creation logic to populate and free the `SystemPrompt` field correctly, ensuring proper memory management. (`runner/nexa-sdk/llm.go` [[1]](diffhunk://#diff-c7f4cb014457f0fdb35114c961df789e8a78f77eb21dbb66cd722e7d52c9d378R71-R74) [[2]](diffhunk://#diff-c7f4cb014457f0fdb35114c961df789e8a78f77eb21dbb66cd722e7d52c9d378R103-R105); `runner/nexa-sdk/vlm.go` [[3]](diffhunk://#diff-320d67897b9d3d5a43aad7f3df7576a237ec7e615a2568a1bb65778ddf36d4dbR65-R68) [[4]](diffhunk://#diff-320d67897b9d3d5a43aad7f3df7576a237ec7e615a2568a1bb65778ddf36d4dbR99-R101)
* Passed the `systemPrompt` value into model initialization for both LLM and VLM inference paths. (`runner/cmd/nexa-cli/infer.go` [[1]](diffhunk://#diff-80e517e48dd824f85f30788bc28f60809fbadc82896404db3263a72f5b2c5883R172) [[2]](diffhunk://#diff-80e517e48dd824f85f30788bc28f60809fbadc82896404db3263a72f5b2c5883R297)

**Prompt File Handling**

* Enhanced both LLM and VLM inference logic to support reading a prompt from a file, applying the chat template, and generating a response before entering the REPL mode. (`runner/cmd/nexa-cli/infer.go` [[1]](diffhunk://#diff-80e517e48dd824f85f30788bc28f60809fbadc82896404db3263a72f5b2c5883R186-R221) [[2]](diffhunk://#diff-80e517e48dd824f85f30788bc28f60809fbadc82896404db3263a72f5b2c5883R311-R346)