### PR TITLE
fix: update fie chooser logic to include .npy files and tokenizer.jso…

### DIFF
--- a/runner/nexa-sdk/llm.go
+++ b/runner/nexa-sdk/llm.go
@@ -69,9 +69,9 @@ func (lci LlmCreateInput) toCPtr() *C.ml_LlmCreateInput {
 		cPtr.config.chat_template_content = C.CString(lci.Config.ChatTemplateContent)
 	}
 	// Add system prompt support
-	// if lci.Config.SystemPrompt != "" {
-	// 	cPtr.config.system_prompt = C.CString(lci.Config.SystemPrompt)
-	// }
+	if lci.Config.SystemPrompt != "" {
+		cPtr.config.system_prompt = C.CString(lci.Config.SystemPrompt)
+	}
 
 	return cPtr
 }
@@ -100,9 +100,9 @@ func freeLlmCreateInput(cPtr *C.ml_LlmCreateInput) {
 		if cPtr.config.chat_template_content != nil {
 			C.free(unsafe.Pointer(cPtr.config.chat_template_content))
 		}
-		// if cPtr.config.system_prompt != nil {
-		// 	C.free(unsafe.Pointer(cPtr.config.system_prompt))
-		// }
+		if cPtr.config.system_prompt != nil {
+			C.free(unsafe.Pointer(cPtr.config.system_prompt))
+		}
 
 		// Free the main structure
 		C.free(unsafe.Pointer(cPtr))

--- a/runner/nexa-sdk/vlm.go
+++ b/runner/nexa-sdk/vlm.go
@@ -63,9 +63,9 @@ func (vci VlmCreateInput) toCPtr() *C.ml_VlmCreateInput {
 		cPtr.config.chat_template_content = C.CString(vci.Config.ChatTemplateContent)
 	}
 	// Add system prompt support
-	// if vci.Config.SystemPrompt != "" {
-	// 	cPtr.config.system_prompt = C.CString(vci.Config.SystemPrompt)
-	// }
+	if vci.Config.SystemPrompt != "" {
+		cPtr.config.system_prompt = C.CString(vci.Config.SystemPrompt)
+	}
 
 	return cPtr
 }
@@ -96,9 +96,9 @@ func freeVlmCreateInput(cPtr *C.ml_VlmCreateInput) {
 		if cPtr.config.chat_template_content != nil {
 			C.free(unsafe.Pointer(cPtr.config.chat_template_content))
 		}
-		// if cPtr.config.system_prompt != nil {
-		// 	C.free(unsafe.Pointer(cPtr.config.system_prompt))
-		// }
+		if cPtr.config.system_prompt != nil {
+			C.free(unsafe.Pointer(cPtr.config.system_prompt))
+		}
 
 		// Free the main structure
 		C.free(unsafe.Pointer(cPtr))


### PR DESCRIPTION
…n even when onnx files do not exist, and comment out system_prompt fields because they are not in bridge ml.h yet