### PR TITLE
feat(cli): add image max length parameter to generation config

### DIFF
--- a/runner/cmd/nexa-cli/infer.go
+++ b/runner/cmd/nexa-cli/infer.go
@@ -30,22 +30,23 @@ const modelLoadFailMsg = `⚠️ Oops. Model failed to load.
 
 var (
 	// disableStream *bool // reuse in run.go
-	ngl          int32
-	maxTokens    int32
-	enableThink  bool
-	hideThink    bool
-	prompt       []string
-	taskType     string
-	query        string
-	document     []string
-	input        string
-	output       string
-	voice        string
-	listVoice    bool
-	speechSpeed  float64
-	systemPrompt string
-	language     string
-	listLanguage bool
+	ngl            int32
+	maxTokens      int32
+	imageMaxLength int32
+	enableThink    bool
+	hideThink      bool
+	prompt         []string
+	taskType       string
+	query          string
+	document       []string
+	input          string
+	output         string
+	voice          string
+	listVoice      bool
+	speechSpeed    float64
+	systemPrompt   string
+	language       string
+	listLanguage   bool
 )
 
 var (
@@ -64,6 +65,7 @@ func infer() *cobra.Command {
 	inferCmd.Flags().SortFlags = false
 	inferCmd.Flags().Int32VarP(&ngl, "ngl", "n", 999, "[llm|vlm] num of layers pass to gpu")
 	inferCmd.Flags().Int32VarP(&maxTokens, "max-tokens", "", 2048, "[llm|vlm] max tokens")
+	inferCmd.Flags().Int32VarP(&imageMaxLength, "max-image-length", "", 512, "[vlm] max image length")
 	inferCmd.Flags().BoolVarP(&enableThink, "think", "", true, "[llm|vlm] enable thinking mode")
 	inferCmd.Flags().BoolVarP(&hideThink, "hide-think", "", false, "[llm|vlm] hide thinking output")
 	inferCmd.Flags().StringVarP(&systemPrompt, "system-prompt", "s", "", "[llm|vlm] system prompt to set model behavior")
@@ -294,7 +296,7 @@ func inferVLM(manifest *types.ModelManifest, quant string) {
 		Config: nexa_sdk.ModelConfig{
 			NCtx:         4096,
 			NGpuLayers:   ngl,
-			SystemPrompt: systemPrompt, // Add system prompt support
+			SystemPrompt: systemPrompt,
 		},
 	})
 	spin.Stop()
@@ -397,9 +399,10 @@ func inferVLM(manifest *types.ModelManifest, quant string) {
 				PromptUTF8: tmplOut.FormattedText,
 				OnToken:    on_token,
 				Config: &nexa_sdk.GenerationConfig{
-					MaxTokens:  maxTokens,
-					ImagePaths: images,
-					AudioPaths: audios,
+					MaxTokens:      maxTokens,
+					ImagePaths:     images,
+					ImageMaxLength: imageMaxLength,
+					AudioPaths:     audios,
 				},
 			})
 			if err != nil {

--- a/runner/nexa-sdk/common.go
+++ b/runner/nexa-sdk/common.go
@@ -197,12 +197,13 @@ func freeSamplerConfig(cPtr *C.ml_SamplerConfig) {
 }
 
 type GenerationConfig struct {
-	MaxTokens     int32
-	Stop          []string
-	NPast         int32
-	SamplerConfig *SamplerConfig
-	ImagePaths    []string
-	AudioPaths    []string
+	MaxTokens      int32
+	Stop           []string
+	NPast          int32
+	SamplerConfig  *SamplerConfig
+	ImagePaths     []string
+	ImageMaxLength int32
+	AudioPaths     []string
 }
 
 func (gc GenerationConfig) toCPtr() *C.ml_GenerationConfig {
@@ -212,7 +213,7 @@ func (gc GenerationConfig) toCPtr() *C.ml_GenerationConfig {
 
 	cPtr.max_tokens = C.int32_t(gc.MaxTokens)
 	cPtr.n_past = C.int32_t(gc.NPast)
-
+	cPtr.image_max_length = C.int32_t(gc.ImageMaxLength)
 	if len(gc.Stop) > 0 {
 		cPtr.stop, cPtr.stop_count = sliceToCCharArray(gc.Stop)
 	}


### PR DESCRIPTION
- Introduced `imageMaxLength` to the `infer` command for better control over image input size.
- Updated `GenerationConfig` struct to include `ImageMaxLength`.
- Adjusted related function calls to accommodate the new parameter.