### PR TITLE
chore(vscode): add Prettier configuration for code formatting

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["esbenp.prettier-vscode"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+  "editor.formatOnSave": true,
+  "[json]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[yaml]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  }
+}


### PR DESCRIPTION
This pull request adds configuration to help standardize code formatting in the project by recommending and enabling the Prettier extension in VS Code. The changes ensure that JSON and YAML files are automatically formatted on save using Prettier.

Editor and formatting configuration:

* [`.vscode/extensions.json`](diffhunk://#diff-c16655a98a3ee89a7636a59c59a72b0e93649e3a1e947327cfc43a1336b4e912R1-R3): Adds a recommendation for the `esbenp.prettier-vscode` extension to encourage all contributors to use Prettier for consistent formatting.
* [`.vscode/settings.json`](diffhunk://#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357R1-R11): Configures VS Code to format files on save, specifically setting Prettier as the default formatter for JSON and YAML files and enabling format-on-save for those file types.