### PR TITLE
Fix: Handle array of content parts for messages

### DIFF
--- a/runner/server/handler/completion.go
+++ b/runner/server/handler/completion.go
@@ -360,6 +360,42 @@ func chatCompletionsVLM(c *gin.Context, param ChatCompletionRequest) {
 				Contents: contents,
 			})
 
+		case *[]openai.ChatCompletionContentPartTextParam:
+			contents := make([]nexa_sdk.VlmContent, 0, len(*content))
+
+			for _, ct := range *content {
+				if *msg.GetRole() == "system" {
+					systemPrompt += ct.Text
+				}
+				contents = append(contents, nexa_sdk.VlmContent{
+					Type: nexa_sdk.VlmContentTypeText,
+					Text: ct.Text,
+				})
+			}
+
+			messages = append(messages, nexa_sdk.VlmChatMessage{
+				Role:     nexa_sdk.VlmRole(*msg.GetRole()),
+				Contents: contents,
+			})
+
+		case *[]openai.ChatCompletionAssistantMessageParamContentArrayOfContentPartUnion:
+			contents := make([]nexa_sdk.VlmContent, 0, len(*content))
+
+			for _, ct := range *content {
+
+				switch *ct.GetType() {
+				case "text":
+					contents = append(contents, nexa_sdk.VlmContent{
+						Type: nexa_sdk.VlmContentTypeText,
+						Text: *ct.GetText(),
+					})
+				}
+				messages = append(messages, nexa_sdk.VlmChatMessage{
+					Role:     nexa_sdk.VlmRole(*msg.GetRole()),
+					Contents: contents,
+				})
+			}
+
 		default:
 			c.JSON(http.StatusBadRequest, map[string]any{"error": "unknown content type"})
 			return


### PR DESCRIPTION
Hi there! I'm really loving this project.

I've encountered an issue when using [array of contents](https://platform.openai.com/docs/api-reference/chat/create#chat-create-messages-system-message-content-array-of-content-parts) in messages on `nexa serve`.

Currently, only requests like the following work:

```bash
curl -X POST http://127.0.0.1:18181/v1/chat/completions \
  -H "Content-Type: application/json" -d '{
    "model": "NexaAI/Qwen3-VL-2B-Instruct-GGUF",
    "messages": [
      { "role": "system", "content": "You always speak in spanish" },
      { "role": "user", "content": "Hey" },
      { "role": "assistant", "content": "Hola! En que puedo ayudarte hoy?" },
      { "role": "user", "content": "tell me a joke" }
    ],
    "stream": true
  }'
```

Requests using an array of contents return:

```json
{"error":"unknown content type"}
```

Example request that fails:

```bash
curl -X POST http://127.0.0.1:18181/v1/chat/completions \
  -H "Content-Type: application/json" -d '{
    "model": "NexaAI/Qwen3-VL-2B-Instruct-GGUF",
    "messages": [
      {
        "role": "system",
        "content": [ { "type": "text", "text": "You always speak in spanish" } ]
      },
      {
        "role": "user",
        "content": [ { "type": "text", "text": "Hey" } ]
      },
      {
        "role": "assistant",
        "content": [ { "type": "text", "text": "Hola! En que puedo ayudarte hoy?" } ]
      },
      {
        "role": "user",
        "content": [ { "type": "text", "text": "tell me a joke" } ]
      }
    ],
    "stream": true
  }'
```

This PR updates the handling of message content arrays, following the approach described in [`openai-go/chatcompletion.go::AsAny()`](https://github.com/openai/openai-go/blob/ae042a437e4ebef4dffe088bf01d087ac94feaf2/chatcompletion.go#L2097-L2105)