### PR TITLE
fix(serve): vlm nonblocking missing image max length

### DIFF
--- a/runner/server/handler/chat.go
+++ b/runner/server/handler/chat.go
@@ -562,10 +562,11 @@ func chatCompletionsVLM(c *gin.Context, param ChatCompletionRequest) {
 		genOut, err := p.Generate(nexa_sdk.VlmGenerateInput{
 			PromptUTF8: formatted.FormattedText,
 			Config: &nexa_sdk.GenerationConfig{
-				MaxTokens:     int32(param.MaxCompletionTokens.Value),
-				SamplerConfig: samplerConfig,
-				ImagePaths:    images,
-				AudioPaths:    audios,
+				MaxTokens:      int32(param.MaxCompletionTokens.Value),
+				SamplerConfig:  samplerConfig,
+				ImagePaths:     images,
+				AudioPaths:     audios,
+				ImageMaxLength: param.ImageMaxLength,
 			},
 		},
 		)


### PR DESCRIPTION
as #770 ,
#757 has fix nexa serve streaming mode, but missing blocking mode