### PR TITLE
fix(completion): change `choices` from null to [] for compatibility with some OpenAI-compatible API clients, such as Cherry Studio

### DIFF
--- a/runner/server/handler/chat.go
+++ b/runner/server/handler/chat.go
@@ -253,7 +253,8 @@ func chatCompletionsLLM(c *gin.Context, param ChatCompletionRequest) {
 			resWg.Wait()
 			if param.StreamOptions.IncludeUsage.Value {
 				c.SSEvent("", openai.ChatCompletionChunk{
-					Usage: profile2Usage(res.ProfileData),
+					Choices: []openai.ChatCompletionChunkChoice{},
+					Usage:   profile2Usage(res.ProfileData),
 				})
 			}
 
@@ -541,7 +542,8 @@ func chatCompletionsVLM(c *gin.Context, param ChatCompletionRequest) {
 			resWg.Wait()
 			if param.StreamOptions.IncludeUsage.Value {
 				c.SSEvent("", openai.ChatCompletionChunk{
-					Usage: profile2Usage(res.ProfileData),
+					Choices: []openai.ChatCompletionChunkChoice{},
+					Usage:   profile2Usage(res.ProfileData),
 				})
 			}
 


### PR DESCRIPTION
Some OpenAI-compatible API clients will report an error when the choices field in the response content is null, such as Cherry Studio.