### PR TITLE
fix: Replace TryLock with blocking Lock in GIL middleware to prevent 429 errors

### DIFF
--- a/runner/server/middleware/gil.go
+++ b/runner/server/middleware/gil.go
@@ -10,15 +10,10 @@ import (
 var lock sync.Mutex
 
 func GIL(c *gin.Context) {
-	locked := lock.TryLock()
-
-	if !locked {
-		c.JSON(http.StatusTooManyRequests, "locked by other request")
-		c.Abort()
-		return
-	}
-
+	// Block and wait for lock instead of immediately failing
+	// This prevents 429 errors when requests queue up briefly
+	lock.Lock()
 	defer lock.Unlock()
+	
 	c.Next()
-
 }


### PR DESCRIPTION
## 🐛 Bug Fix

Fixes #833

## Problem

The GIL middleware was causing excessive HTTP 429 "Too Many Requests" errors for local embedding requests, even with single concurrent requests. The root cause was `TryLock()` returning immediately when the lock is held, causing legitimate requests to fail instead of waiting.

### Observed Issues:
- Hundreds of 429 errors in server logs
- Failed requests with 200µs response times (too fast = not processed)
- Severe throughput degradation
- Unreliable embedding service for production use

## Solution

Replaced `sync.Mutex.TryLock()` with `sync.Mutex.Lock()` in the GIL middleware:

- **Before**: Requests fail immediately with 429 if lock is held
- **After**: Requests queue and wait for lock availability

This maintains the same serialization guarantees while eliminating false-positive rate limiting.

## Changes

- Modified `runner/server/middleware/gil.go`
- Replaced non-blocking `TryLock()` with blocking `Lock()`
- Simplified error handling (no 429 check needed)

## Testing

**Environment:**
- macOS Sonoma (Apple Silicon)
- NexaAI SDK v0.2.57
- localhost:8010

**Before fix:**
curl -X POST localhost:8010/v1/embeddings \
  -H "Content-Type: application/json" \
  -d '{"model":"embeddinggemma-300m-npu","input":"test"}'
# Result: HTTP 429 errors frequently**After fix:**
# Multiple concurrent requests
for i in {1..5}; do
  curl -X POST localhost:8010/v1/embeddings \
    -H "Content-Type: application/json" \
    -d '{"model":"embeddinggemma-300m-npu","input":"test '$i'"}' &
done
# Result: All requests succeed with HTTP 200## Impact

- ✅ **Reliability**: Eliminates false-positive 429 errors
- ✅ **Performance**: Minimal latency increase (requests wait instead of fail)
- ✅ **Compatibility**: No breaking changes
- ✅ **Serialization**: Maintains existing concurrency control

## Related

- Issue: #833
- Component: Server middleware (GIL)