### PR TITLE
feat(docker): add data dir

### DIFF
--- a/runner/release/linux/Dockerfile
+++ b/runner/release/linux/Dockerfile
@@ -17,8 +17,9 @@ RUN DEBIAN_FRONTEND=noninteractive \
 
 ARG TARGETARCH
 COPY nexa_sdk.$TARGETARCH/ /opt/nexa_sdk/
-
 RUN ln -s /opt/nexa_sdk/nexa /usr/local/bin/nexa
+
+RUN mkdir -p /data && mkdir -p /root/.cache && ln -s /data /root/.cache/nexa.ai
 
 EXPOSE 18181
 ENTRYPOINT ["nexa"]


### PR DESCRIPTION
change mount dir to `/data`, so user no longer needs to pass the complex `/root/.cache/nexa.ai`

``` bash
docker run --rm -it --privileged \
  -v /path/to/data:/data \
  -e NEXA_TOKEN="YOUR_LONG_TOKEN_HERE" \
  nexa4ai/nexasdk infer NexaAI/Granite-4.0-h-350M-NPU
```