### PR TITLE
chore(build): track public geniex-qairt repo, bump to latest main

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/ggml-org/llama.cpp
 [submodule "third-party/geniex-qairt"]
 	path = third-party/geniex-qairt
-	url = git@github.com:qcom-ai-hub/geniex-qairt-plugin.git
+	url = https://github.com/qualcomm/geniex-qairt-plugin


### PR DESCRIPTION
## What

- Repoint the \`geniex-qairt\` submodule from the private \`qcom-ai-hub/geniex-qairt-plugin\` to the public \`qualcomm/geniex-qairt-plugin\` repo (\`.gitmodules\` URL).
- Bump the pinned commit to the public \`main\` HEAD: \`e30fbae\` → \`37a15d5\`.

## Why

The submodule clone's local \`origin\` already pointed at the public \`qualcomm\` mirror, while \`.gitmodules\` still referenced the private \`qcom-ai-hub\` repo — the two had diverged. This aligns \`.gitmodules\` and the synced \`.git/config\` so future \`git submodule update\` tracks the public repo, and advances the pin to its latest \`main\`.

## Notes

- \`third-party/llama.cpp\` is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)