### PR TITLE
docs: set custom domain to geniex.aihub.qualcomm.com

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -2,6 +2,7 @@
   "$schema": "https://mintlify.com/docs.json",
   "theme": "mint",
   "name": "Qualcomm® AI Hub GenieX",
+  "customDomain": "geniex.aihub.qualcomm.com",
   "colors": {
     "primary": "#2a2aea",
     "light": "#2a2aea",


### PR DESCRIPTION
## Summary

Sets `customDomain` in `docs/docs.json` so Mintlify serves the GenieX docs at `geniex.aihub.qualcomm.com`.
