### PR TITLE
docs(sdk): fix license name in README — Apache-2.0 → BSD-3-Clause

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Smartphone (please complete the following information):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE/pr_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pr_template.md
@@ -1,0 +1,27 @@
+## Pull Request
+
+**Description**
+A clear and concise description of what this pull request does.
+
+**Related Issue**
+Link to the issue that this pull request addresses (e.g., `Fixes #123`).
+
+**Type of Change**
+Please delete options that are not relevant.
+- Bug fix (non-breaking change which fixes an issue)
+- New feature (non-breaking change which adds functionality)
+- Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- Documentation update
+
+**Checklist**
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my own code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] My changes generate no new warnings
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit tests pass locally with my changes
+- [ ] Any dependent changes have been merged and published in downstream modules
+
+**Additional Context**
+Add any other context or screenshots about the pull request here.

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions" # See documentation for possible values
+    directory: "/" # This points to .github/workflows
+    schedule:
+      interval: "daily"

--- a/.github/workflows/qcom-preflight-checks.yml
+++ b/.github/workflows/qcom-preflight-checks.yml
@@ -1,0 +1,24 @@
+name: QC Preflight Checks
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  preflight:
+    name: Run QC Preflight Checks
+    uses: qualcomm/qcom-reusable-workflows/.github/workflows/reusable-qcom-preflight-checks-orchestrator.yml@v2
+    with:
+      enable-semgrep-scan: true
+      enable-dependency-review: true
+      enable-repolinter-check: true
+      enable-copyright-license-check: true
+      enable-commit-email-check: true
+      enable-commit-msg-check: false
+      enable-armor-checkers: false

--- a/.github/workflows/stale-issues.yaml
+++ b/.github/workflows/stale-issues.yaml
@@ -1,0 +1,22 @@
+name: 'Close stale issues and pull requests with no recent activity'
+on:
+  schedule:
+  - cron: "30 1 * * *"
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/stale@v10
+      with:
+        stale-issue-message: 'Remove the stale label or add a comment to reset the inactivity timer.'
+        stale-pr-message: 'Remove the stale label or add a comment to reset the inactivity timer'
+        days-before-stale: 30
+        days-before-close: -1
+        remove-stale-when-updated: true
+        remove-issue-stale-when-updated: true
+        remove-pr-stale-when-updated: true

--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+[GitHub.CoC](mailto:github.coc@qti.qualcomm.com?subject=GitHub%20Qualcomm%20Code%20of%20Conduct%20Report).
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @zhycheng614 @alexchen4ai
+* @vinovo @Davidqian123 @zhycheng614 @alexchen4ai @RemiliaForever @zhiyuan8 @mengshengwu

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @zhycheng614 @alexchen4ai

--- a/NOTICE
+++ b/NOTICE
@@ -135,7 +135,7 @@ This document provides information about third-party libraries used in the Genie
 - **URL**: https://github.com/nlohmann/json
 - **Description**: JSON for Modern C++
 - **Used in**: llama.cpp
-- **License File**: [geniex-bridge/third-party/llama.cpp/licenses/LICENSE-jsonhpp](https://github.com/ggerganov/llama.cpp/blob/master/licenses/LICENSE-jsonhpp)
+- **License File**: [third-party/llama.cpp/licenses/LICENSE-jsonhpp](https://github.com/ggerganov/llama.cpp/blob/master/licenses/LICENSE-jsonhpp)
 
 ---
 

--- a/NOTICE
+++ b/NOTICE
@@ -109,7 +109,7 @@ This document provides information about third-party libraries used in the Genie
 - **Copyright**: Copyright (c) 2016 Wenzel Jakob
 - **URL**: https://github.com/pybind/pybind11
 - **Description**: Seamless operability between C++11 and Python
-- **License File**: [geniex-bridge/third-party/pybind11/LICENSE](https://github.com/pybind/pybind11/blob/master/LICENSE)
+- **License File**: [pybind11 LICENSE](https://github.com/pybind/pybind11/blob/master/LICENSE)
 
 ### xtensor
 

--- a/NOTICE
+++ b/NOTICE
@@ -126,7 +126,7 @@ This document provides information about third-party libraries used in the Genie
 - **URL**: https://github.com/yhirose/cpp-httplib
 - **Description**: C++ single-file header-only HTTP/HTTPS library
 - **Used in**: llama.cpp
-- **License File**: [geniex-bridge/third-party/llama.cpp/licenses/LICENSE-httplib](https://github.com/ggerganov/llama.cpp/blob/master/licenses/LICENSE-httplib)
+- **License File**: [third-party/llama.cpp/licenses/LICENSE-httplib](https://github.com/ggerganov/llama.cpp/blob/master/licenses/LICENSE-httplib)
 
 ### nlohmann/json
 

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ NexaSDK uses a dual licensing model:
 
 ### CPU/GPU Components
 
-Licensed under [Apache License 2.0](LICENSE).
+Licensed under [BSD 3-Clause License](LICENSE).
 
 ### NPU Components
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,31 @@
+How to Report a Potential Vulnerability?
+========================================
+
+If you would like to report a public issue (for example, one with a released
+CVE number), please report it as a
+[GitHub issue](https://github.com/qualcomm/nexa-sdk/issues/new).
+If you have a patch ready, submit it following the same procedure as any
+other patch as described in [CONTRIBUTING.md](CONTRIBUTING.md).
+
+If you are dealing with a not-yet released or urgent issue, please contact us
+via our [Product Security team](mailto:product-security@qualcomm.com) or
+see our
+[Report a Bug](https://www.qualcomm.com/company/product-security/report-a-bug)
+page. Please include the following details while reporting a vulnerability:
+- Description of the vulnerability
+- Steps to reproduce
+- Affected versions
+- Potential impact
+- Any relevant logs or screenshots
+
+## Coordinated Disclosure
+
+We follow a Coordinated Vulnerability Disclosure (CVD) process:
+
+- **Initial Response**: We will acknowledge your report within 48 hours.
+
+- **Investigation**: Our team will investigate the issue and provide updates.
+
+- **Resolution**: We will work with you to resolve the issue and prepare a fix.
+
+- **Disclosure**: Once the fix is ready, we will disclose the vulnerability and notify affected users.

--- a/bindings/android/app/src/main/cpp/android_utils.cpp
+++ b/bindings/android/app/src/main/cpp/android_utils.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 //
 // Created by echonfl on 2025/11/3.
 //

--- a/bindings/android/app/src/main/cpp/android_utils.h
+++ b/bindings/android/app/src/main/cpp/android_utils.h
@@ -1,3 +1,6 @@
+// Copyright (c) 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 //
 // Created by echonfl on 2025/11/3.
 //

--- a/bindings/android/app/src/main/cpp/geniex_sdk.cpp
+++ b/bindings/android/app/src/main/cpp/geniex_sdk.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 #include <android/log.h>
 #include <dlfcn.h>
 #include <jni.h>

--- a/bindings/android/app/src/main/cpp/jni_cb.cpp
+++ b/bindings/android/app/src/main/cpp/jni_cb.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 #include "jni_cb.h"
 
 #include <cstdint>

--- a/bindings/android/app/src/main/cpp/jni_cb.h
+++ b/bindings/android/app/src/main/cpp/jni_cb.h
@@ -1,3 +1,6 @@
+// Copyright (c) 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 #pragma once
 #include <jni.h>
 

--- a/bindings/android/app/src/main/cpp/jniutils.cpp
+++ b/bindings/android/app/src/main/cpp/jniutils.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 #include "jniutils.h"
 
 #include <android/log.h>

--- a/bindings/android/app/src/main/cpp/jniutils.h
+++ b/bindings/android/app/src/main/cpp/jniutils.h
@@ -1,3 +1,6 @@
+// Copyright (c) 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 #pragma once
 
 #include <jni.h>

--- a/bindings/android/app/src/main/cpp/llm_bridge_jni.cpp
+++ b/bindings/android/app/src/main/cpp/llm_bridge_jni.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 #include <dlfcn.h>
 #include <jni.h>
 #include <pthread.h>

--- a/bindings/android/app/src/main/cpp/model_manager_jni.cpp
+++ b/bindings/android/app/src/main/cpp/model_manager_jni.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 #include <jni.h>
 
 #include <atomic>

--- a/bindings/android/app/src/main/cpp/vlm_bridge_jni.cpp
+++ b/bindings/android/app/src/main/cpp/vlm_bridge_jni.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 #include <android/log.h>
 #include <jni.h>
 #include <pthread.h>

--- a/repolint.json
+++ b/repolint.json
@@ -1,0 +1,390 @@
+{
+  "$schema": "https://raw.githubusercontent.com/todogroup/repolinter/master/rulesets/schema.json",
+  "version": 2,
+  "axioms": {
+    "linguist": "language",
+    "licensee": "license",
+    "packagers": "packager"
+  },
+  "rules": {
+    "license-file-exists": {
+      "level": "error",
+      "rule": {
+        "type": "file-existence",
+        "options": {
+          "globsAny": [
+            "LICENSE*",
+            "COPYING*",
+            "NOTICE*"
+          ],
+          "nocase": true
+        }
+      }
+    },
+    "readme-file-exists": {
+      "level": "error",
+      "rule": {
+        "type": "file-existence",
+        "options": {
+          "globsAny": [
+            "README*"
+          ],
+          "nocase": true
+        }
+      }
+    },
+    "contributing-file-exists": {
+      "level": "warning",
+      "rule": {
+        "type": "file-existence",
+        "options": {
+          "globsAny": [
+            "{docs/,.github/,}CONTRIB*"
+          ],
+          "nocase": true
+        }
+      }
+    },
+    "code-of-conduct-file-exists": {
+      "level": "warning",
+      "rule": {
+        "type": "file-existence",
+        "options": {
+          "globsAny": [
+            "{docs/,.github/,}CODEOFCONDUCT*",
+            "{docs/,.github/,}CODE-OF-CONDUCT*",
+            "{docs/,.github/,}CODE_OF_CONDUCT*"
+          ],
+          "nocase": true
+        }
+      }
+    },
+    "changelog-file-exists": {
+      "level": "warning",
+      "rule": {
+        "type": "file-existence",
+        "options": {
+          "globsAny": [
+            "CHANGELOG*"
+          ],
+          "nocase": true
+        }
+      }
+    },
+    "readme-references-license": {
+      "level": "error",
+      "rule": {
+        "type": "file-contents",
+        "options": {
+          "globsAll": [
+            "README*"
+          ],
+          "content": "license|notice",
+          "flags": "i"
+        }
+      }
+    },
+    "binaries-not-present": {
+      "level": "warning",
+      "rule": {
+        "type": "file-type-exclusion",
+        "options": {
+          "type": [
+            "**/*.exe",
+            "**/*.dll",
+            "**/*.o",
+            "**/*.so",
+            "!node_modules/**"
+          ]
+        }
+      }
+    },
+    "test-directory-exists": {
+      "level": "warning",
+      "rule": {
+        "type": "directory-existence",
+        "options": {
+          "globsAny": [
+            "**/test*",
+            "**/specs",
+            "**/*test*"
+          ],
+          "nocase": true
+        }
+      }
+    },
+    "integrates-with-ci": {
+      "level": "warning",
+      "rule": {
+        "type": "file-existence",
+        "options": {
+          "globsAny": [
+            ".gitlab-ci.yml",
+            ".travis.yml",
+            "appveyor.yml",
+            ".appveyor.yml",
+            "circle.yml",
+            ".circleci/config.yml",
+            "Jenkinsfile",
+            ".drone.yml",
+            ".github/workflows/*",
+            "azure-pipelines.yml"
+          ]
+        }
+      }
+    },
+    "source-license-headers-exist": {
+      "level": "error",
+      "rule": {
+        "type": "file-starts-with",
+        "options": {
+          "globsAll": [
+            "**/*.py",
+            "**/*.js",
+            "**/*.c",
+            "**/*.cc",
+            "**/*.cpp",
+            "**/*.h",
+            "**/*.ts",
+            "**/*.rs",
+            "**/*.java",
+            "**/*.go",
+            "**/*.bbclass",
+            "**/*.S",
+            "**/*.hpp"
+          ],
+          "skip-paths-matching": {
+            "patterns": [
+              "babel.config.js",
+              "build\/",
+              "jest.config.js",
+              "node_modules\/",
+              "types\/",
+              "uthash.h",
+              "sdk\/include\/external\/",
+              "third-party\/"
+            ]
+          },
+          "lineCount": 200,
+          "patterns": [
+            "Copyright(\\s)*(\\(c\\)|©)?",
+            "SPDX-License-Identifier|Redistribution and use in source and binary forms, with or without"
+          ],
+          "flags": "i",
+          "succeed-on-non-existent": true
+        }
+      }
+    },
+    "source-qualcomm-license-headers-exist": {
+      "level": "warning",
+      "rule": {
+        "type": "file-starts-with",
+        "options": {
+          "globsAll": [
+            "**/*.py",
+            "**/*.js",
+            "**/*.c",
+            "**/*.cc",
+            "**/*.cpp",
+            "**/*.h",
+            "**/*.ts",
+            "**/*.sh",
+            "**/*.rs",
+            "**/*.java",
+            "**/*.go",
+            "**/*.bbclass",
+            "**/*.S",
+            "**/*.hpp"
+          ],
+          "skip-paths-matching": {
+            "patterns": [
+              "babel.config.js",
+              "build\/",
+              "jest.config.js",
+              "node_modules\/",
+              "types\/",
+              "uthash.h",
+              "sdk\/include\/external\/",
+              "third-party\/"
+            ]
+          },
+          "lineCount": 200,
+          "patterns": [
+            "(Copyright|©).*Qualcomm Innovation Center, Inc|Qualcomm Technologies, Inc|Copyright (\\(c\\)|©) (20(1[2-9]|2[0-2])(-|,|\\s)*)+ The Linux Foundation"
+          ],
+          "flags": "i"
+        }
+      }
+    },
+    "github-issue-template-exists": {
+      "level": "warning",
+      "rule": {
+        "type": "file-existence",
+        "options": {
+          "globsAny": [
+            "ISSUE_TEMPLATE*",
+            "ISSUE_TEMPLATE/**",
+            ".github/ISSUE_TEMPLATE*",
+            ".github/ISSUE_TEMPLATE/**"
+          ]
+        }
+      }
+    },
+    "github-pull-request-template-exists": {
+      "level": "warning",
+      "rule": {
+        "type": "file-existence",
+        "options": {
+          "globsAny": [
+            "PULL_REQUEST_TEMPLATE*",
+            "PULL_REQUEST_TEMPLATE/**",
+            ".github/PULL_REQUEST_TEMPLATE*",
+            ".github/PULL_REQUEST_TEMPLATE/**"
+          ]
+        }
+      }
+    },
+    "javascript-package-metadata-exists": {
+      "level": "warning",
+      "where": [
+        "language=javascript"
+      ],
+      "rule": {
+        "type": "file-existence",
+        "options": {
+          "globsAny": [
+            "package.json"
+          ]
+        }
+      }
+    },
+    "ruby-package-metadata-exists": {
+      "level": "warning",
+      "where": [
+        "language=ruby"
+      ],
+      "rule": {
+        "type": "file-existence",
+        "options": {
+          "globsAny": [
+            "Gemfile"
+          ]
+        }
+      }
+    },
+    "java-package-metadata-exists": {
+      "level": "warning",
+      "where": [
+        "language=java"
+      ],
+      "rule": {
+        "type": "file-existence",
+        "options": {
+          "globsAny": [
+            "pom.xml",
+            "build.xml",
+            "build.gradle"
+          ]
+        }
+      }
+    },
+    "python-package-metadata-exists": {
+      "level": "warning",
+      "where": [
+        "language=python"
+      ],
+      "rule": {
+        "type": "file-existence",
+        "options": {
+          "globsAny": [
+            "setup.py",
+            "requirements.txt"
+          ]
+        }
+      }
+    },
+    "rust-package-metadata-exists": {
+      "level": "error",
+      "where": [
+         "language=rust"
+      ],
+      "rule": {
+        "type": "file-existence",
+        "options": {
+          "globsAny": [
+            "**/Cargo.toml",
+            "**/Cargo.lock"
+          ]
+        }
+      }
+    },
+    "objective-c-package-metadata-exists": {
+      "level": "warning",
+      "where": [
+        "language=objective-c"
+      ],
+      "rule": {
+        "type": "file-existence",
+        "options": {
+          "globsAny": [
+            "Cartfile",
+            "Podfile",
+            "**/*.podspec"
+          ]
+        }
+      }
+    },
+    "swift-package-metadata-exists": {
+      "level": "warning",
+      "where": [
+        "language=swift"
+      ],
+      "rule": {
+        "type": "file-existence",
+        "options": {
+          "globsAny": [
+            "Package.swift"
+          ]
+        }
+      }
+    },
+    "erlang-package-metadata-exists": {
+      "level": "warning",
+      "where": [
+        "language=erlang"
+      ],
+      "rule": {
+        "type": "file-existence",
+        "options": {
+          "globsAny": [
+            "rebar.config"
+          ]
+        }
+      }
+    },
+    "elixir-package-metadata-exists": {
+      "level": "warning",
+      "where": [
+        "language=elixir"
+      ],
+      "rule": {
+        "type": "file-existence",
+        "options": {
+          "globsAny": [
+            "mix.exs"
+          ]
+        }
+      }
+    },
+    "license-detectable-by-licensee": {
+      "level": "off",
+      "where": [
+        "license=*"
+      ],
+      "rule": {
+        "type": "license-detectable-by-licensee",
+        "options": {}
+      }
+    }
+  }
+}

--- a/sdk/include/build_config.h
+++ b/sdk/include/build_config.h
@@ -1,3 +1,6 @@
+// Copyright (c) 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 #pragma once
 
 namespace geniex::build_config {

--- a/sdk/include/geniex.h
+++ b/sdk/include/geniex.h
@@ -1,3 +1,6 @@
+// Copyright (c) 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 #pragma once
 
 /**

--- a/sdk/include/image_utils.h
+++ b/sdk/include/image_utils.h
@@ -1,3 +1,6 @@
+// Copyright (c) 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 #pragma once
 
 #include <cstdio>

--- a/sdk/include/logging.h
+++ b/sdk/include/logging.h
@@ -1,3 +1,6 @@
+// Copyright (c) 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 #pragma once
 
 #define FMT_HEADER_ONLY

--- a/sdk/include/plugin/ILlm.h
+++ b/sdk/include/plugin/ILlm.h
@@ -1,3 +1,6 @@
+// Copyright (c) 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 #pragma once
 
 #include "IValidatable.h"

--- a/sdk/include/plugin/IValidatable.h
+++ b/sdk/include/plugin/IValidatable.h
@@ -1,3 +1,6 @@
+// Copyright (c) 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 #pragma once
 
 /**

--- a/sdk/include/plugin/IVlm.h
+++ b/sdk/include/plugin/IVlm.h
@@ -1,3 +1,6 @@
+// Copyright (c) 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 #pragma once
 
 #include "IValidatable.h"

--- a/sdk/include/plugin/Plugin.h
+++ b/sdk/include/plugin/Plugin.h
@@ -1,3 +1,6 @@
+// Copyright (c) 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 #pragma once
 
 #include "ILlm.h"

--- a/sdk/include/profile.h
+++ b/sdk/include/profile.h
@@ -1,3 +1,6 @@
+// Copyright (c) 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 #pragma once
 
 #include "geniex.h"

--- a/sdk/include/registry.h
+++ b/sdk/include/registry.h
@@ -1,3 +1,6 @@
+// Copyright (c) 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 #pragma once
 
 #include <filesystem>

--- a/sdk/include/utils.h
+++ b/sdk/include/utils.h
@@ -1,3 +1,6 @@
+// Copyright (c) 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 #pragma once
 
 #include <filesystem>

--- a/sdk/include/validation.h
+++ b/sdk/include/validation.h
@@ -1,3 +1,6 @@
+// Copyright (c) 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 #pragma once
 
 /**

--- a/sdk/model-manager/include/geniex_model.h
+++ b/sdk/model-manager/include/geniex_model.h
@@ -1,3 +1,6 @@
+// Copyright (c) 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 #pragma once
 
 /**

--- a/sdk/plugins/llama_cpp/include/htp_session.h
+++ b/sdk/plugins/llama_cpp/include/htp_session.h
@@ -1,3 +1,6 @@
+// Copyright (c) 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 #pragma once
 
 namespace geniex {

--- a/sdk/plugins/llama_cpp/include/llm.h
+++ b/sdk/plugins/llama_cpp/include/llm.h
@@ -1,3 +1,6 @@
+// Copyright (c) 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 #pragma once
 
 #include <optional>

--- a/sdk/plugins/llama_cpp/include/params.h
+++ b/sdk/plugins/llama_cpp/include/params.h
@@ -1,3 +1,6 @@
+// Copyright (c) 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 #pragma once
 
 #include <optional>

--- a/sdk/plugins/llama_cpp/include/profiler.h
+++ b/sdk/plugins/llama_cpp/include/profiler.h
@@ -1,3 +1,6 @@
+// Copyright (c) 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 #pragma once
 
 #include <chrono>

--- a/sdk/plugins/llama_cpp/include/threadpool.h
+++ b/sdk/plugins/llama_cpp/include/threadpool.h
@@ -1,3 +1,6 @@
+// Copyright (c) 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 #pragma once
 
 #include "ggml-cpu.h"  // ggml_threadpool_params, ggml_threadpool_new/free

--- a/sdk/plugins/llama_cpp/include/vlm.h
+++ b/sdk/plugins/llama_cpp/include/vlm.h
@@ -1,3 +1,6 @@
+// Copyright (c) 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 #pragma once
 
 #include "chat.h"

--- a/sdk/plugins/llama_cpp/src/htp_session.cpp
+++ b/sdk/plugins/llama_cpp/src/htp_session.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 #include "htp_session.h"
 
 #include <atomic>

--- a/sdk/plugins/llama_cpp/src/llm.cpp
+++ b/sdk/plugins/llama_cpp/src/llm.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 #include "llm.h"
 
 #include <algorithm>

--- a/sdk/plugins/llama_cpp/src/params.cpp
+++ b/sdk/plugins/llama_cpp/src/params.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 #include "params.h"
 
 #include <cstring>

--- a/sdk/plugins/llama_cpp/src/plugin.cpp
+++ b/sdk/plugins/llama_cpp/src/plugin.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 #include "plugin/Plugin.h"
 
 #include <cstdlib>

--- a/sdk/plugins/llama_cpp/src/profiler.cpp
+++ b/sdk/plugins/llama_cpp/src/profiler.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 #include "profiler.h"
 
 namespace common {

--- a/sdk/plugins/llama_cpp/src/threadpool.cpp
+++ b/sdk/plugins/llama_cpp/src/threadpool.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 #include "threadpool.h"
 
 #include <string>

--- a/sdk/plugins/llama_cpp/src/vlm.cpp
+++ b/sdk/plugins/llama_cpp/src/vlm.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 #include "vlm.h"
 
 #include <cstring>

--- a/sdk/plugins/qairt/include/llm.h
+++ b/sdk/plugins/qairt/include/llm.h
@@ -1,3 +1,6 @@
+// Copyright (c) 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 #pragma once
 
 #include <memory>

--- a/sdk/plugins/qairt/include/qnn_runtime_utils.h
+++ b/sdk/plugins/qairt/include/qnn_runtime_utils.h
@@ -1,3 +1,6 @@
+// Copyright (c) 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 #pragma once
 
 #if defined(_WIN32)

--- a/sdk/plugins/qairt/include/vlm.h
+++ b/sdk/plugins/qairt/include/vlm.h
@@ -1,3 +1,6 @@
+// Copyright (c) 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 #pragma once
 
 #include <memory>

--- a/sdk/plugins/qairt/src/llm.cpp
+++ b/sdk/plugins/qairt/src/llm.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 #include "llm.h"
 
 #include <cstring>

--- a/sdk/plugins/qairt/src/plugin.cpp
+++ b/sdk/plugins/qairt/src/plugin.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 #include "plugin/Plugin.h"
 
 #include <cstdlib>

--- a/sdk/src/device.cpp
+++ b/sdk/src/device.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 // Single source of truth for the user-facing device alias table
 // (cpu / gpu / npu / hybrid → concrete device_id + n_gpu_layers).
 // Language bindings (Go CLI, Python, Android/JNI) call through to this.

--- a/sdk/src/error.cpp
+++ b/sdk/src/error.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 #include "geniex.h"
 
 /**

--- a/sdk/src/llm.cpp
+++ b/sdk/src/llm.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 #include <cstring>
 #include <memory>
 

--- a/sdk/src/logging_bridge.cpp
+++ b/sdk/src/logging_bridge.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 // Trampoline used by the Rust model manager to reach the geniex log
 // callback (`geniex_log`, declared in sdk/include/logging.h).
 //

--- a/sdk/src/ml.cpp
+++ b/sdk/src/ml.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 #include <stdlib.h>
 
 #include "geniex.h"

--- a/sdk/src/registry.cpp
+++ b/sdk/src/registry.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 
 
 #if defined(_WIN32)

--- a/sdk/src/utils.cpp
+++ b/sdk/src/utils.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 #include "utils.h"
 
 #if defined(_WIN32)

--- a/sdk/src/version.cpp
+++ b/sdk/src/version.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 #include "build_config.h"
 
 namespace geniex::build_config {

--- a/sdk/src/vlm.cpp
+++ b/sdk/src/vlm.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 #include <cstring>
 #include <memory>
 


### PR DESCRIPTION
## Summary
- The README stated "Licensed under Apache License 2.0" but the actual `LICENSE` file is BSD 3-Clause
- Corrects the reference to match the actual license

## Test plan
- [ ] Verify LICENSE file content matches the README reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)