### PR TITLE
ci: drop CLONE_PAT once repos go public

### DIFF
--- a/.github/workflows/_build-cli.yml
+++ b/.github/workflows/_build-cli.yml
@@ -49,7 +49,6 @@ jobs:
         with:
           fetch-depth: 1
           submodules: false
-          token: ${{ secrets.CLONE_PAT }}
 
       - name: Detect build version
         id: version

--- a/.github/workflows/_build-docker.yml
+++ b/.github/workflows/_build-docker.yml
@@ -42,7 +42,6 @@ jobs:
         with:
           fetch-depth: 1
           submodules: false
-          token: ${{ secrets.CLONE_PAT }}
 
       - name: Detect build version
         id: version

--- a/.github/workflows/_build-sdk.yml
+++ b/.github/workflows/_build-sdk.yml
@@ -71,7 +71,6 @@ jobs:
         with:
           fetch-depth: 1
           submodules: recursive
-          token: ${{ secrets.CLONE_PAT }}
 
       - name: Detect build version
         id: version

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -17,7 +17,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          token: ${{ secrets.CLONE_PAT }}
 
       - name: Resolve C/C++ file list
         id: files
@@ -53,7 +52,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          token: ${{ secrets.CLONE_PAT }}
 
       - name: Setup Python 3.10
         uses: actions/setup-python@v6
@@ -95,8 +93,6 @@ jobs:
     steps:
       - name: Checkout source
         uses: actions/checkout@v6
-        with:
-          token: ${{ secrets.CLONE_PAT }}
 
       - name: Setup Go
         uses: actions/setup-go@v6
@@ -120,7 +116,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          token: ${{ secrets.CLONE_PAT }}
 
       - name: Resolve Rust file list
         id: files

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -78,7 +78,6 @@ jobs:
           # avoids "missing base" failures on multi-commit PRs.
           fetch-depth: 0
           submodules: false
-          token: ${{ secrets.CLONE_PAT }}
 
       - name: Resolve changed files
         id: files


### PR DESCRIPTION
## What

Removes the \`CLONE_PAT\` token override from all source checkouts in \`_build-sdk\`, \`_build-cli\`, \`_build-docker\`, \`_test\`, and \`_lint\` (8 sites).

## Why

\`CLONE_PAT\` was introduced in #1102 so the submodule-recursive checkouts could authenticate independently of \`GH_PAT\` (which that PR repurposed for dispatching geniex's publish-s3). It is only needed while the repo and its submodules are **private**.

Once \`qualcomm/nexa-sdk\`, \`geniex-qairt-plugin\`, and \`geniex-proc\` are **public**, anonymous clone needs no PAT — the default \`GITHUB_TOKEN\` suffices for all source checkouts. \`GH_PAT\` stays in place solely for dispatching geniex's \`chore/publish-s3\`.

## Merge order / follow-up

- **Draft until the repos are public.** Stacked on \`#1102\` (\`ci/publish-s3-via-geniex\`); GitHub will retarget the base to \`main\` after #1102 merges.
- After merge: delete the \`CLONE_PAT\` secret from the repo (no longer referenced).