### PR TITLE
ci: TEMPORARY one-time stale Windows CMake build-dir cleanup

### DIFF
--- a/.github/workflows/_build-sdk.yml
+++ b/.github/workflows/_build-sdk.yml
@@ -236,6 +236,32 @@ jobs:
         if: matrix.platform == 'windows-arm64'
         uses: ./.github/actions/setup-vcvars
 
+      # TEMPORARY (remove after one run): the windows-arm64 runner is
+      # self-hosted, so sdk/build-* persists across runs. The qualcomm/nexa-sdk
+      # -> qualcomm/GenieX rename moved the checkout path, leaving a stale
+      # CMakeCache.txt that points at the old c:/a/nexa-sdk/... source dir and
+      # makes cmake configure hard-error. Delete any such stale build dir once,
+      # then this step (and its PR) should be reverted.
+      - name: One-time stale CMake build-dir cleanup (Windows)
+        if: matrix.platform == 'windows-arm64'
+        shell: powershell
+        run: |
+          $ErrorActionPreference = "Stop"
+          Get-ChildItem -Path "sdk" -Directory -Filter "build-*" -ErrorAction SilentlyContinue | ForEach-Object {
+            $cacheFile = Join-Path $_.FullName "CMakeCache.txt"
+            if (Test-Path $cacheFile) {
+              $cachedSrc = (Select-String -Path $cacheFile -Pattern "^CMAKE_HOME_DIRECTORY:" | Select-Object -First 1)
+              $cachedSrc = if ($cachedSrc) { (($cachedSrc.Line -split "=", 2)[1]) -replace "\\", "/" } else { "" }
+              $currentSrc = (Resolve-Path "sdk").Path -replace "\\", "/"
+              if ($cachedSrc -and ($cachedSrc -ne $currentSrc)) {
+                Write-Host "Removing stale build dir $($_.FullName): cached source '$cachedSrc' != current '$currentSrc'"
+                Remove-Item -Recurse -Force $_.FullName
+              } else {
+                Write-Host "Keeping $($_.FullName): cached source '$cachedSrc' matches '$currentSrc'"
+              }
+            }
+          }
+
       - name: Build SDK (Windows)
         if: matrix.platform == 'windows-arm64'
         shell: powershell


### PR DESCRIPTION
## ⚠️ Temporary — trigger once, then revert

This adds a **single-use** cleanup step; it is **not** a permanent fix. Once it has run successfully on the windows-arm64 runner, this PR should be reverted (or the step removed) — see [Reviewer call-outs](#reviewer-call-outs).

## What

Adds a temporary `One-time stale CMake build-dir cleanup (Windows)` step to the `windows-arm64` SDK build in `.github/workflows/_build-sdk.yml`, right before `Build SDK (Windows)`. It deletes any `sdk/build-*` directory whose `CMakeCache.txt` still records the pre-rename source path.

## Why

The windows-arm64 runner is **self-hosted**, so `sdk/build-$PRESET` persists across runs. Today's repo rename **`qualcomm/nexa-sdk` → `qualcomm/GenieX`** moved the checkout from `C:/a/nexa-sdk/...` to `C:/a/GenieX/...`. The leftover `CMakeCache.txt` from the old path made `cmake` configure hard-error, failing `build-sdk / windows-arm64` in run [28269888814](https://github.com/qualcomm/GenieX/actions/runs/28269888814):

```
CMake Error: The source "C:/a/GenieX/GenieX/sdk/CMakeLists.txt" does not match the
source "c:/a/nexa-sdk/nexa-sdk/sdk/CMakeLists.txt" used to generate cache.
cmake configure failed: 1
```

A rename is a one-time event, so we don't want a permanent guard in CI — just clear the stale dir once.

## How to trigger (draft PR)

On a **draft** PR, `pr-check.yml` runs lint only (`build-sdk` is gated on `pull_request.draft == false`), so the cleanup won't auto-run. To run it once:

- **Actions → PR Check → Run workflow** (`workflow_dispatch`) against branch `fix/windows-stale-cmake-cache` — dispatch isn't draft-gated, so `build-sdk` → the cleanup step will execute.

After the run succeeds, ping me and I'll revert the step.

## Alternative — purely manual (no CI)

If you'd rather not run CI, an admin can delete the stale dirs on the self-hosted windows-arm64 runner directly (PowerShell, from the runner's work dir, typically `C:\a\GenieX\GenieX`):

```powershell
# SDK build dirs
Remove-Item -Recurse -Force C:\a\GenieX\GenieX\sdk\build-*
# llama.cpp build dir (if it also carries a stale cache)
Get-ChildItem C:\a\GenieX\GenieX -Recurse -Directory -Filter 'build-arm64-windows-*' |
  Remove-Item -Recurse -Force
```

The `.ccache` dir is keyed on `CCACHE_DIR` (independent of the build dir), so deleting `build-*` does **not** lose the compile cache — the next configure regenerates the cache and rebuilds fast.

## Reviewer call-outs

- **Scope:** CI-only, single file, single temporary step. No SDK/runtime code.
- **Lifecycle:** revert this PR (or drop the step) after one successful run. Keeping it as a draft so it doesn't merge by accident.
- **Not in this PR:** the separate `build-python-sdist` PEP 639 / `License :: OSI Approved :: BSD License` failure in the same run.
- **Not addressed:** the `v0.3.8` tag force-push (`f758439` → `9c7af50`); `v0.3.9` is the live tag.