### PR TITLE
fix: PEP 639 license classifier + bazel go-bindings repo rename

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -82,7 +82,7 @@ use_repo(
     "com_github_lmittmann_tint",
     "com_github_mattn_go_runewidth",
     "com_github_openai_openai_go_v3",
-    "com_github_qualcomm_nexa_sdk_bindings_go",
+    "com_github_qualcomm_geniex_bindings_go",
     "com_github_schollz_progressbar_v3",
     "com_github_spf13_cobra",
     "com_github_spf13_pflag",

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -22,7 +22,6 @@ classifiers = [
   "Development Status :: 4 - Beta",
   "Intended Audience :: Developers",
   "Topic :: Software Development :: Libraries :: Python Modules",
-  "License :: OSI Approved :: BSD License",
 ]
 
 [project.scripts]


### PR DESCRIPTION
Two CI fixes uncovered while validating the v0.3.x release pipeline (alpha run [28272671316](https://github.com/qualcomm/GenieX/actions/runs/28272671316)).

## 1. `bindings/python/pyproject.toml` — drop deprecated BSD license classifier (PEP 639)

`setuptools>=77` **hard-errors** when a project declares *both* an SPDX `license` expression and a legacy `License ::` trove classifier. `pyproject.toml` already sets `license = "BSD-3-Clause"`, so `"License :: OSI Approved :: BSD License"` is redundant. This failed `build-python-sdist` in release run 28269888814:

```
setuptools.errors.InvalidConfigError: License classifiers have been superseded by
license expressions (see PEP 639). Please remove: License :: OSI Approved :: BSD License
```

`bindings/python/pyproject.toml` is canonical — `sync_siblings.py` regenerates the `geniex-llama-cpp` / `geniex-qairt` configs from it, so this one change fixes all three sdists. Verified by building all three with Python 3.12 + setuptools 82.

## 2. `MODULE.bazel` — update go-bindings `use_repo` name after the repo rename

The `qualcomm/nexa-sdk` → `qualcomm/GenieX` rename changed the Go module path to `github.com/qualcomm/GenieX/bindings/go`, so gazelle's `go_deps` extension now generates `com_github_qualcomm_geniex_bindings_go`. `MODULE.bazel` still listed the old `com_github_qualcomm_nexa_sdk_bindings_go` in `use_repo()`, which broke **all three** bazel/CLI jobs in the alpha run:
- `build-cli / linux-arm64` (`//cli:artifact`)
- `build-cli / windows-arm64` (Windows installer)
- `publish-docker / build` (`//cli/release/linux`)

```
module extension ...%go_deps does not generate repository
com_github_qualcomm_nexa_sdk_bindings_go, yet it is imported ... MODULE.bazel:71:24
Fix the use_repo calls by running 'bazel mod tidy'.
```

Renamed the single stale `use_repo` entry to the new name (equivalent to `bazel mod tidy`; only that one entry changed).

## Reviewer call-outs

- Both are CI-unblocking config fixes; no runtime/API change.
- Separate from the Windows CMake-cache poisoning (handled by deleting the stale `actions/cache` entry + draft PR #1108).
- Validated against alpha tag `v0.3.10-alpha.1`.