### PR TITLE
chore(ci): deploy docs only via workflow_dispatch

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,10 +1,6 @@
 name: Deploy Docs to GitHub Pages
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - "docs/**"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## What

The docs deploy workflow no longer triggers on `push` to `main`. It now runs only via `workflow_dispatch` (manual trigger).

## Why

Avoid auto-deploying docs on every `docs/**` change; deploys are now triggered manually when intended.