### PR TITLE
Update license metadata for Python and Maven artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -500,9 +500,9 @@ jobs:
           <version>${VERSION}</version>
           <packaging>aar</packaging>
           <name>${ARTIFACT_ID}</name>
-          <description>GenieX Android AAR - multi-platform AI inference runtime (Snapdragon / Hexagon).</description>
+          <description>GenieX Android AAR - multi-platform AI inference runtime (Snapdragon / Hexagon). Subject to Qualcomm Terms of Use: https://www.qualcomm.com/site/terms-of-use</description>
           <url>https://github.com/qualcomm/GenieX</url>
-          <licenses><license><name>Apache License, Version 2.0</name><url>https://www.apache.org/licenses/LICENSE-2.0.txt</url><distribution>repo</distribution></license></licenses>
+          <licenses><license><name>BSD 3-Clause License</name><url>https://github.com/qcom-ai-hub/geniex/blob/main/LICENSE</url><distribution>repo</distribution></license><license><name>Qualcomm Terms of Use</name><url>https://www.qualcomm.com/site/terms-of-use</url><distribution>repo</distribution></license></licenses>
           <developers><developer><id>qualcomm-aisw</id><name>Qualcomm AISW</name><organization>Qualcomm</organization><organizationUrl>https://www.qualcomm.com</organizationUrl></developer></developers>
           <scm><connection>scm:git:git://github.com/qualcomm/GenieX.git</connection><developerConnection>scm:git:ssh://github.com/qualcomm/GenieX.git</developerConnection><url>https://github.com/qualcomm/GenieX</url></scm>
           </project>

--- a/bindings/android/pom.xml
+++ b/bindings/android/pom.xml
@@ -11,7 +11,12 @@
 <licenses>
   <license>
     <name>BSD 3-Clause License</name>
-    <url>https://opensource.org/licenses/BSD-3-Clause</url>
+    <url>https://github.com/qcom-ai-hub/geniex/blob/main/LICENSE</url>
+    <distribution>repo</distribution>
+  </license>
+  <license>
+    <name>Qualcomm Terms of Use</name>
+    <url>https://www.qualcomm.com/site/terms-of-use</url>
     <distribution>repo</distribution>
   </license>
 </licenses>

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -194,6 +194,6 @@ the sdist, and the TestPyPI smoke-test workflow.
 
 ## License
 
-BSD 3-Clause — see [LICENSE](LICENSE).
+BSD 3-Clause — see [LICENSE](https://github.com/qcom-ai-hub/geniex/blob/main/LICENSE).
 
 Use of this package is also subject to Qualcomm's [Terms of Use](https://www.qualcomm.com/site/terms-of-use).

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -33,7 +33,10 @@ notebook = ["ipywidgets>=8"]
 test = ["pytest>=7.0"]
 
 [project.urls]
-# TODO: add the current GenieX-Bridge project homepage.
+Homepage = "https://github.com/qualcomm/GenieX"
+Repository = "https://github.com/qualcomm/GenieX"
+License = "https://github.com/qcom-ai-hub/geniex/blob/main/LICENSE"
+"Terms of Use" = "https://www.qualcomm.com/site/terms-of-use"
 
 [tool.setuptools]
 include-package-data = true

--- a/cli/release/linux/BUILD.bazel
+++ b/cli/release/linux/BUILD.bazel
@@ -77,6 +77,9 @@ oci_image(
         "org.opencontainers.image.vendor": "Qualcomm",
         "org.opencontainers.image.licenses": "BSD-3-Clause",
         "org.opencontainers.image.url": "https://github.com/qualcomm/GenieX",
+        "org.opencontainers.image.documentation": "https://github.com/qcom-ai-hub/geniex/blob/main/LICENSE",
+        "io.qualcomm.license.url": "https://github.com/qcom-ai-hub/geniex/blob/main/LICENSE",
+        "io.qualcomm.terms-of-use.url": "https://www.qualcomm.com/site/terms-of-use",
     },
     target_compatible_with = ["@platforms//os:linux"],
     tars = [


### PR DESCRIPTION
 #  Summary
 
 - Update Maven POM (both pom.xml and release workflow inline POM) to reference the correct BSD 3-Clause license URL and add Qualcomm Terms of Use as a second license entry.
 - Add Qualcomm Terms of Use notice to the Python README license section.