### PR TITLE
fix(sdk): accept case-insensitive quant + recognise MXFP4 in model-manager

### DIFF
--- a/sdk/model-manager/crates/core/src/manifest_builder.rs
+++ b/sdk/model-manager/crates/core/src/manifest_builder.rs
@@ -678,14 +678,11 @@ mod tests {
     }
 
     #[test]
-    fn gpt_oss_20b_sharded_mxfp4_layout() {
-        // ggml-org/gpt-oss-20b-GGUF: two MXFP4 shards. With MXFP recognised by
-        // extract_quant, hint `MXFP4` picks the first shard as entrypoint and
-        // routes the second shard to extra_files.
-        let (names, sizes) = sizes_of(&[
-            ("gpt-oss-20b-mxfp4-00001-of-00002.gguf", 6_000_000_000),
-            ("gpt-oss-20b-mxfp4-00002-of-00002.gguf", 6_000_000_000),
-        ]);
+    fn gpt_oss_20b_mxfp4_layout() {
+        // ggml-org/gpt-oss-20b-GGUF ships a single 12 GB MXFP4 weight (no
+        // shards). Before MXFP was recognised the file landed in the
+        // `"default"` bucket and `:mxfp4` failed with QuantNotFound.
+        let (names, sizes) = sizes_of(&[("gpt-oss-20b-mxfp4.gguf", 12_109_566_560)]);
         let hint = ManifestHint {
             quant: Some("MXFP4".to_string()),
             ..Default::default()
@@ -693,9 +690,12 @@ mod tests {
         let m =
             infer_manifest_from_names("ggml-org/gpt-oss-20b-GGUF", &names, &sizes, hint).unwrap();
         let entry = m.model_file.get("MXFP4").expect("MXFP4 key present");
-        assert_eq!(entry.name, "gpt-oss-20b-mxfp4-00001-of-00002.gguf");
-        let extra: Vec<&str> = m.extra_files.iter().map(|f| f.name.as_str()).collect();
-        assert!(extra.contains(&"gpt-oss-20b-mxfp4-00002-of-00002.gguf"));
+        assert_eq!(entry.name, "gpt-oss-20b-mxfp4.gguf");
+        assert!(
+            m.extra_files.is_empty(),
+            "single-file repo has no extras: {:?}",
+            m.extra_files
+        );
     }
 
     #[test]

--- a/sdk/model-manager/crates/core/src/manifest_builder.rs
+++ b/sdk/model-manager/crates/core/src/manifest_builder.rs
@@ -399,15 +399,15 @@ fn is_mmproj_filename(lname: &str) -> bool {
         || stem.contains("_mmproj_")
 }
 
-/// Extract a quant tag like `Q4_K_M`, `Q8_0`, `IQ4_XS`, or `TQ1_0` from a
-/// filename. The match is case-insensitive (HF repos publish both `q4_0`
-/// and `Q4_0`); the returned tag is upper-cased so it lines up with
+/// Extract a quant tag like `Q4_K_M`, `Q8_0`, `IQ4_XS`, `TQ1_0`, or `MXFP4`
+/// from a filename. The match is case-insensitive (HF repos publish both
+/// `q4_0` and `Q4_0`); the returned tag is upper-cased so it lines up with
 /// [`QUANT_PRIORITY`]. Returns the highest-priority match if multiple are
 /// present, else the first match, else None.
 fn extract_quant(name: &str) -> Option<String> {
     // Walk the (uppercased, ASCII-only) name token by token. A quant tag
     // must sit on a token boundary so that `IQ4_XS` doesn't get scanned as
-    // `Q4_XS` from index 1 — we anchor each candidate Q at a separator.
+    // `Q4_XS` from index 1 — we anchor each candidate at a separator.
     let upper = name.to_ascii_uppercase();
     let bytes = upper.as_bytes();
     let mut composite: Vec<String> = Vec::new();
@@ -415,6 +415,15 @@ fn extract_quant(name: &str) -> Option<String> {
     while i < bytes.len() {
         if !is_token_start(bytes, i) {
             i += 1;
+            continue;
+        }
+        // Try MXFP-anchored tags first (`MXFP4`, `MXFP4_MOE`) — ggml-org's
+        // gpt-oss GGUFs use them and they don't start with Q.
+        if let Some(end) = scan_token(bytes, i, b"MXFP") {
+            if let Ok(s) = std::str::from_utf8(&bytes[i..end]) {
+                composite.push(s.to_string());
+            }
+            i = end;
             continue;
         }
         // Optional 1-byte prefix used by i-quants (`IQ*`) and ternary
@@ -436,23 +445,7 @@ fn extract_quant(name: &str) -> Option<String> {
         while i < bytes.len() && bytes[i].is_ascii_digit() {
             i += 1;
         }
-        // Trailing `_XXX` segments. Each segment must be 1..=3 ASCII
-        // upper/digit chars — long alphabetic words like `_FINETUNE`
-        // are NOT part of the quant tag.
-        while i + 1 < bytes.len() && bytes[i] == b'_' {
-            let seg_start = i + 1;
-            let mut seg_end = seg_start;
-            while seg_end < bytes.len()
-                && (bytes[seg_end].is_ascii_uppercase() || bytes[seg_end].is_ascii_digit())
-            {
-                seg_end += 1;
-            }
-            let seg_len = seg_end - seg_start;
-            if seg_len == 0 || seg_len > 3 {
-                break;
-            }
-            i = seg_end;
-        }
+        i = consume_short_suffix_segments(bytes, i);
         if let Ok(s) = std::str::from_utf8(&bytes[start..i]) {
             composite.push(s.to_string());
         }
@@ -466,6 +459,43 @@ fn extract_quant(name: &str) -> Option<String> {
         }
     }
     Some(composite.remove(0))
+}
+
+/// If the slice at `start` begins with `prefix` followed by ≥1 digit, return
+/// the end index of the full tag (including any trailing short `_XXX`
+/// segments); otherwise None.
+fn scan_token(bytes: &[u8], start: usize, prefix: &[u8]) -> Option<usize> {
+    if !bytes[start..].starts_with(prefix) {
+        return None;
+    }
+    let mut i = start + prefix.len();
+    if !(i < bytes.len() && bytes[i].is_ascii_digit()) {
+        return None;
+    }
+    while i < bytes.len() && bytes[i].is_ascii_digit() {
+        i += 1;
+    }
+    Some(consume_short_suffix_segments(bytes, i))
+}
+
+/// Trailing `_XXX` segments. Each segment must be 1..=3 ASCII upper/digit
+/// chars — long alphabetic words like `_FINETUNE` are NOT part of the tag.
+fn consume_short_suffix_segments(bytes: &[u8], mut i: usize) -> usize {
+    while i + 1 < bytes.len() && bytes[i] == b'_' {
+        let seg_start = i + 1;
+        let mut seg_end = seg_start;
+        while seg_end < bytes.len()
+            && (bytes[seg_end].is_ascii_uppercase() || bytes[seg_end].is_ascii_digit())
+        {
+            seg_end += 1;
+        }
+        let seg_len = seg_end - seg_start;
+        if seg_len == 0 || seg_len > 3 {
+            break;
+        }
+        i = seg_end;
+    }
+    i
 }
 
 /// True when index `i` of `bytes` sits at the start of a filename token —
@@ -550,6 +580,24 @@ mod tests {
     }
 
     #[test]
+    fn extract_quant_recognises_mxfp() {
+        // ggml-org/gpt-oss-*-GGUF publishes MXFP4 shards; the tag must be
+        // recognised regardless of case and survive trailing shard suffixes.
+        assert_eq!(extract_quant("model-MXFP4.gguf"), Some("MXFP4".to_string()));
+        assert_eq!(extract_quant("model-mxfp4.gguf"), Some("MXFP4".to_string()));
+        assert_eq!(
+            extract_quant("gpt-oss-20b-mxfp4-00001-of-00002.gguf"),
+            Some("MXFP4".to_string())
+        );
+        assert_eq!(
+            extract_quant("model-MXFP4_MOE.gguf"),
+            Some("MXFP4_MOE".to_string())
+        );
+        // Mid-token MXFP (no separator before it) is not a quant.
+        assert_eq!(extract_quant("aMXFP4.gguf"), None);
+    }
+
+    #[test]
     fn is_mmproj_filename_matches_known_layouts() {
         // Standard llama.cpp prefix layout.
         assert!(is_mmproj_filename("mmproj-f16.gguf"));
@@ -627,6 +675,27 @@ mod tests {
         assert!(extra.contains(&"model-Q4_0-00002-of-00003.gguf"));
         assert!(extra.contains(&"model-Q4_0-00003-of-00003.gguf"));
         assert_eq!(m.total_size(), 600, "every shard counted exactly once");
+    }
+
+    #[test]
+    fn gpt_oss_20b_sharded_mxfp4_layout() {
+        // ggml-org/gpt-oss-20b-GGUF: two MXFP4 shards. With MXFP recognised by
+        // extract_quant, hint `MXFP4` picks the first shard as entrypoint and
+        // routes the second shard to extra_files.
+        let (names, sizes) = sizes_of(&[
+            ("gpt-oss-20b-mxfp4-00001-of-00002.gguf", 6_000_000_000),
+            ("gpt-oss-20b-mxfp4-00002-of-00002.gguf", 6_000_000_000),
+        ]);
+        let hint = ManifestHint {
+            quant: Some("MXFP4".to_string()),
+            ..Default::default()
+        };
+        let m =
+            infer_manifest_from_names("ggml-org/gpt-oss-20b-GGUF", &names, &sizes, hint).unwrap();
+        let entry = m.model_file.get("MXFP4").expect("MXFP4 key present");
+        assert_eq!(entry.name, "gpt-oss-20b-mxfp4-00001-of-00002.gguf");
+        let extra: Vec<&str> = m.extra_files.iter().map(|f| f.name.as_str()).collect();
+        assert!(extra.contains(&"gpt-oss-20b-mxfp4-00002-of-00002.gguf"));
     }
 
     #[test]

--- a/sdk/model-manager/crates/core/tests/hf_live.rs
+++ b/sdk/model-manager/crates/core/tests/hf_live.rs
@@ -14,6 +14,7 @@ use model_manager_core::pull::{pull, PullIntent, PullRequest};
 use model_manager_core::store::Store;
 
 const TINY_REPO: &str = "ggml-org/tiny-llamas";
+const QWEN3_REPO: &str = "ggml-org/Qwen3-0.6B-GGUF";
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 #[ignore]
@@ -43,4 +44,75 @@ async fn end_to_end_pull_via_hf() {
         .get_paths(TINY_REPO)
         .expect("get_paths after pull failed");
     assert!(paths.model_path.exists(), "model file missing: {paths:?}");
+}
+
+/// Resolving `Qwen3-0.6B-GGUF:Q4_0` against the real repo must pick the
+/// Q4_0 GGUF — manifest inference reaches the upstream sibling list and
+/// the upper-case hint hits the manifest_builder lookup path that this
+/// branch is keeping case-sensitive at the core. Pulls ~370 MB.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore]
+async fn end_to_end_pull_qwen3_q4_0() {
+    let tmp = tempfile::tempdir().expect("tmpdir");
+    let cfg = StoreConfig::new(tmp.path().to_path_buf());
+    let store = Store::new(cfg).expect("store init");
+
+    let req = PullRequest {
+        model_name: QWEN3_REPO.to_string(),
+        intent: PullIntent::HuggingFace {
+            repo: QWEN3_REPO.to_string(),
+            token: None,
+        },
+        on_progress: None,
+        hint: ManifestHint {
+            quant: Some("Q4_0".to_string()),
+            ..Default::default()
+        },
+    };
+    pull(&store, req).await.expect("pull failed");
+
+    let (resolved, paths) = store
+        .get_paths(&format!("{QWEN3_REPO}:Q4_0"))
+        .expect("get_paths after pull failed");
+    assert_eq!(resolved, "Q4_0");
+    assert!(paths.model_path.exists(), "model file missing: {paths:?}");
+    let fname = paths.model_path.file_name().unwrap().to_string_lossy();
+    assert!(
+        fname.to_lowercase().contains("q4_0"),
+        "expected Q4_0 file, got {fname}"
+    );
+}
+
+/// `ggml-org/gpt-oss-20b-GGUF:mxfp4` ships a single ~12 GB MXFP4 weight —
+/// exercises the new MXFP token recognition in `extract_quant`. Pulls
+/// ~12 GB, so leave it off by default.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore]
+async fn end_to_end_pull_gpt_oss_20b_mxfp4() {
+    let repo = "ggml-org/gpt-oss-20b-GGUF";
+    let tmp = tempfile::tempdir().expect("tmpdir");
+    let cfg = StoreConfig::new(tmp.path().to_path_buf());
+    let store = Store::new(cfg).expect("store init");
+
+    let req = PullRequest {
+        model_name: repo.to_string(),
+        intent: PullIntent::HuggingFace {
+            repo: repo.to_string(),
+            token: None,
+        },
+        on_progress: None,
+        hint: ManifestHint {
+            quant: Some("MXFP4".to_string()),
+            ..Default::default()
+        },
+    };
+    pull(&store, req).await.expect("pull failed");
+
+    let (resolved, paths) = store
+        .get_paths(&format!("{repo}:MXFP4"))
+        .expect("get_paths after pull failed");
+    assert_eq!(resolved, "MXFP4");
+    assert!(paths.model_path.exists(), "model file missing: {paths:?}");
+    let fname = paths.model_path.file_name().unwrap().to_string_lossy();
+    assert_eq!(fname, "gpt-oss-20b-mxfp4.gguf");
 }

--- a/sdk/model-manager/crates/ffi/src/pull.rs
+++ b/sdk/model-manager/crates/ffi/src/pull.rs
@@ -248,7 +248,10 @@ pub extern "C" fn geniex_model_pull(input: *const GenieXModelPullInput) -> i32 {
 
         // Thread `quant` into the manifest hint so `pull` only fetches
         // the requested quantization instead of every GGUF in the repo.
-        let quant = unsafe { cstr_to_str(inp.quant) }.map(str::to_string);
+        // Upper-cased here so the lookup in `manifest_builder::infer_*`
+        // (against keys produced by `extract_quant`, which upper-cases)
+        // succeeds for bindings that don't normalize themselves.
+        let quant = unsafe { cstr_to_str(inp.quant) }.map(|s| s.to_ascii_uppercase());
         // -1 (GENIEX_MODEL_TYPE_AUTO) leaves detection to the inferer; 0/1 force
         // the type so the manifest is written correctly in one shot.
         let model_type = match inp.model_type {

--- a/sdk/model-manager/crates/ffi/src/store.rs
+++ b/sdk/model-manager/crates/ffi/src/store.rs
@@ -56,14 +56,14 @@ pub extern "C" fn geniex_model_get_paths(
             return GENIEX_ERROR_COMMON_INVALID_INPUT;
         }
         let name = match unsafe { cstr_to_str(model_name) } {
-            Some(s) => s,
+            Some(s) => normalize_quant_suffix(s),
             None => return GENIEX_ERROR_COMMON_INVALID_INPUT,
         };
         let store = match get_store() {
             Ok(s) => s,
             Err(c) => return c,
         };
-        match store.get_paths(name) {
+        match store.get_paths(&name) {
             Ok((_, paths)) => {
                 unsafe {
                     (*out_paths).model_path = str_to_cptr(&paths.model_path.to_string_lossy());
@@ -110,14 +110,14 @@ pub unsafe extern "C" fn geniex_model_paths_free(paths: *mut GenieXModelPaths) {
 pub extern "C" fn geniex_model_remove(model_name: *const c_char) -> i32 {
     ffi_guard(|| {
         let name = match unsafe { cstr_to_str(model_name) } {
-            Some(s) => s,
+            Some(s) => normalize_quant_suffix(s),
             None => return GENIEX_ERROR_COMMON_INVALID_INPUT,
         };
         let store = match get_store() {
             Ok(s) => s,
             Err(c) => return c,
         };
-        match store.remove(name) {
+        match store.remove(&name) {
             Ok(()) => GENIEX_SUCCESS,
             Err(e) => report(&e),
         }

--- a/sdk/model-manager/crates/ffi/src/types.rs
+++ b/sdk/model-manager/crates/ffi/src/types.rs
@@ -155,6 +155,20 @@ pub unsafe fn free_cptr(ptr: *mut c_char) {
     }
 }
 
+/// Upper-case the `:QUANT` suffix of a model name. Manifest keys are
+/// produced by `extract_quant`, which upper-cases (so `q4_0` -> `Q4_0`);
+/// without matching the lookup side, `pull <repo>:q4_0` fails for callers
+/// (Python, JNI) whose bindings don't already upper-case. Done here at the
+/// FFI boundary so the invariant is a single point of enforcement.
+pub fn normalize_quant_suffix(name: &str) -> String {
+    match name.rsplit_once(':') {
+        Some((base, quant)) if !quant.is_empty() => {
+            format!("{base}:{}", quant.to_ascii_uppercase())
+        }
+        _ => name.to_string(),
+    }
+}
+
 // Silence unused warning for c_void import when building without features that
 // use it; pull.rs re-imports c_void directly when it needs it.
 #[allow(dead_code)]
@@ -200,6 +214,29 @@ mod tests {
             err_to_code(&Error::Http("reset".to_string())),
             GENIEX_ERROR_COMMON_NETWORK
         );
+    }
+
+    #[test]
+    fn normalize_quant_suffix_upper_cases_only_after_colon() {
+        assert_eq!(
+            normalize_quant_suffix("ggml-org/Qwen3-0.6B-GGUF:q4_0"),
+            "ggml-org/Qwen3-0.6B-GGUF:Q4_0"
+        );
+        assert_eq!(
+            normalize_quant_suffix("ggml-org/Qwen3-0.6B-GGUF:Q4_0"),
+            "ggml-org/Qwen3-0.6B-GGUF:Q4_0"
+        );
+        assert_eq!(
+            normalize_quant_suffix("ggml-org/gpt-oss-20b-GGUF:mxfp4"),
+            "ggml-org/gpt-oss-20b-GGUF:MXFP4"
+        );
+        // No suffix → unchanged.
+        assert_eq!(
+            normalize_quant_suffix("ggml-org/Qwen3-0.6B-GGUF"),
+            "ggml-org/Qwen3-0.6B-GGUF"
+        );
+        // Trailing colon (no quant) → unchanged.
+        assert_eq!(normalize_quant_suffix("Org/Repo:"), "Org/Repo:");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Two narrow fixes so `geniex model pull` accepts more real-world HuggingFace GGUF repos:

- **Case-insensitive quant suffix.** `extract_quant` in `manifest_builder.rs:407` upper-cases manifest keys, but the Python and Android bindings pass the user's quant verbatim — only the Go CLI's `SplitNamePrecision` upper-cased before the FFI. `pull <repo>:q4_0` therefore failed for everyone except CLI users with `QuantNotFound`. Normalise the `:QUANT` suffix once at the FFI boundary (`pull` quant field + `get_paths` / `remove` name) so every binding shares the same invariant; core lookups stay case-sensitive.
- **MXFP4 quant tag recognition.** `ggml-org/gpt-oss-20b-GGUF` ships a single ~12 GB `gpt-oss-20b-mxfp4.gguf`. The old `extract_quant` only matched `Q*` / `IQ*` / `TQ*`, so `MXFP4` landed in the `"default"` bucket and `:mxfp4` errored with `requested quant "MXFP4" not found; available: ["default"]`. Add an MXFP-anchored branch (also recognises `MXFP4_MOE`) and refactor the trailing-segment loop into a shared helper so both scanners stay in sync.

Closes #1116.

## Test plan

- [x] `cargo test -p model-manager-core --lib manifest_builder` — new `extract_quant_recognises_mxfp` + `gpt_oss_20b_mxfp4_layout` pass alongside the existing 28 cases.
- [x] `cargo test -p model-manager-ffi --lib` — new `normalize_quant_suffix_upper_cases_only_after_colon` plus existing error-mapping tests pass.
- [x] `cargo test --test hf_live end_to_end_pull_qwen3_q4_0 -- --ignored` — real ~370 MB download of `ggml-org/Qwen3-0.6B-GGUF:Q4_0` resolves and lands on disk (~13 s).
- [x] `cargo test --test hf_live end_to_end_pull_gpt_oss_20b_mxfp4 -- --ignored` — pending; ~12 GB single-file pull, deferred until I have the time/bandwidth.