### PR TITLE
fix(build): bundle Android NDK libomp.so into the SDK package

### DIFF
--- a/sdk/benchmark/qdc/run_qdc_jobs.py
+++ b/sdk/benchmark/qdc/run_qdc_jobs.py
@@ -209,18 +209,6 @@ def build_android_artifact(
     # on-device; results land in the device's QDC_logs and are auto-collected.
     stage = tmp / "stage"
     shutil.copytree(pkg_dir, stage / "pkg-geniex")
-    # libggml-cpu.so needs libomp.so, which the CLI package doesn't ship but the
-    # Android app provides from extLibs; drop it beside the ggml libs.
-    omp = (
-        HERE.parents[2]
-        / "bindings"
-        / "android"
-        / "app"
-        / "extLibs"
-        / "arm64-v8a"
-        / "libomp.so"
-    )
-    shutil.copy(omp, stage / "pkg-geniex" / "lib" / "llama_cpp" / "libomp.so")
     (stage / "matrix_rows.txt").write_text("\n".join(model_rows(models, device)))
     (stage / "chipset.txt").write_text(CHIPSET.get(device, ""))
     shutil.copytree(HERE / "tests", stage / "tests")

--- a/sdk/plugins/CMakeLists.txt
+++ b/sdk/plugins/CMakeLists.txt
@@ -39,3 +39,14 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
             DESTINATION lib/llama_cpp
             RENAME "libgomp.so.1")
 endif()
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Android")
+    file(GLOB_RECURSE _android_libomp
+        "$ENV{ANDROID_NDK_ROOT}/toolchains/llvm/prebuilt/*/libomp.so")
+    list(FILTER _android_libomp INCLUDE REGEX "/lib/linux/aarch64/libomp.so$")
+    if(NOT _android_libomp)
+        message(FATAL_ERROR "Android NDK libomp.so not found under $ENV{ANDROID_NDK_ROOT}")
+    endif()
+    list(GET _android_libomp 0 _android_libomp)
+    install(FILES "${_android_libomp}" DESTINATION lib/llama_cpp)
+endif()


### PR DESCRIPTION
Closes #1118

`geniex-bench-android-arm64-*.tar.gz` shipped without `libomp.so`, but `libggml-cpu.so` links OpenMP dynamically and crashes at decode without it. Windows/Linux bench archives are already self-contained — the SDK install layer drops their OpenMP runtime into `lib/llama_cpp/`, which `release.yml`'s platform-agnostic `cp -r .../lib/llama_cpp` carries into the archive. Android just lacked the matching install branch, so the QDC harness hand-injected `libomp.so` from `bindings/android/app/extLibs/`.

This adds the Android branch in `sdk/plugins/CMakeLists.txt` (sources `libomp.so` from the NDK, installs to `lib/llama_cpp/`) and drops the now-redundant injection in `run_qdc_jobs.py`, making `pkg-geniex` the single source.

## Test plan

- [x] In the `geniex-toolchain-android:v0.0.1` container, the new `file(GLOB_RECURSE)` + `list(FILTER)` resolves `$ANDROID_NDK_ROOT/.../lib/clang/19/lib/linux/aarch64/libomp.so`; `readelf -h` confirms ELF64 / AArch64. (First attempt's single-`*` glob missed the `lib/clang/<ver>/` segment and tripped the `FATAL_ERROR` — fixed.)
- [x] `build-sdk / android-arm64` runs `cmake --install` green on the `v0.3.13-alpha.2` release run; since the Android branch `FATAL_ERROR`s when libomp.so is unresolved, a green install confirms it is installed into `lib/llama_cpp/`. (`release.yml`'s existing `cp -r .../lib/llama_cpp` then carries it into the tar.gz, same as Windows/Linux.)
- [x] QDC Android scorecard cell decodes without an OpenMP-missing crash using the self-contained tar.gz (no `extLibs` injection) — pending, needs device