### PR TITLE
chore(deps): bump GitHub Actions (checkout, setup-buildx-action, configure-pages)

### DIFF
--- a/.github/workflows/_build-android-aar.yml
+++ b/.github/workflows/_build-android-aar.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout source
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
           submodules: false

--- a/.github/workflows/_build-cli.yml
+++ b/.github/workflows/_build-cli.yml
@@ -45,7 +45,7 @@ jobs:
           git config --global core.longpaths true
 
       - name: Checkout source
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
           submodules: false

--- a/.github/workflows/_build-docker.yml
+++ b/.github/workflows/_build-docker.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - name: Checkout source
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
           submodules: false

--- a/.github/workflows/_build-python-sdist.yml
+++ b/.github/workflows/_build-python-sdist.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout source
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 

--- a/.github/workflows/_build-sdk.yml
+++ b/.github/workflows/_build-sdk.yml
@@ -67,7 +67,7 @@ jobs:
         run: git config --global url."https://github.com/".insteadOf "git@github.com:"
 
       - name: Checkout source
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
           submodules: recursive

--- a/.github/workflows/_build-toolchain-docker.yml
+++ b/.github/workflows/_build-toolchain-docker.yml
@@ -102,7 +102,7 @@ jobs:
         if: >-
           steps.meta.outputs.platforms == 'both' ||
           steps.meta.outputs.platforms == matrix.platform
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to DockerHub
         if: >-

--- a/.github/workflows/_build-toolchain-docker.yml
+++ b/.github/workflows/_build-toolchain-docker.yml
@@ -60,7 +60,7 @@ jobs:
 
     steps:
       - name: Checkout source
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout source
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -49,7 +49,7 @@ jobs:
 
     steps:
       - name: Checkout source
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -92,7 +92,7 @@ jobs:
 
     steps:
       - name: Checkout source
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Go
         uses: actions/setup-go@v6
@@ -113,7 +113,7 @@ jobs:
 
     steps:
       - name: Checkout source
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/_qdc-pytest.yml
+++ b/.github/workflows/_qdc-pytest.yml
@@ -44,7 +44,7 @@ jobs:
     env:
       QDC_API_KEY: ${{ secrets.QDC_API_KEY }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: actions/setup-python@v6
         with:
           python-version: "3.11"

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -72,7 +72,7 @@ jobs:
           git config --global core.protectNTFS false
 
       - name: Checkout source
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           # changed-files diffs against the PR base SHA; fetch-depth 0
           # avoids "missing base" failures on multi-commit PRs.

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -30,7 +30,7 @@ jobs:
       matrix: ${{ steps.set.outputs.matrix }}
       devices: ${{ steps.set.outputs.devices }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - id: set
         env:
           PICK_DEVICE: ${{ github.event.inputs.device }}
@@ -80,7 +80,7 @@ jobs:
     env:
       QDC_API_KEY: ${{ secrets.QDC_API_KEY }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
@@ -118,7 +118,7 @@ jobs:
       matrix:
         device: ${{ fromJson(needs.load-models.outputs.devices) }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: actions/setup-python@v6
         with:
           python-version: "3.11"

--- a/.github/workflows/build-llama-cpp-windows.yml
+++ b/.github/workflows/build-llama-cpp-windows.yml
@@ -37,7 +37,7 @@ jobs:
 
       # Needed for the composite actions; llama.cpp is cloned separately.
       - name: Checkout geniex (for composite actions)
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 1
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,7 +35,7 @@ jobs:
           mkdir _site
           unzip site.zip -d _site
 
-      - uses: actions/configure-pages@v5
+      - uses: actions/configure-pages@v6
 
       - uses: actions/upload-pages-artifact@v5
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 1
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,7 +112,7 @@ jobs:
       signed: ${{ steps.htp.outputs.signed }}
       llama_sha: ${{ steps.htp.outputs.llama_sha }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 1
           submodules: false
@@ -187,7 +187,7 @@ jobs:
       HTP_SIGNED: ${{ needs.overlay-htp.outputs.signed }}
       LLAMA_SHA: ${{ needs.overlay-htp.outputs.llama_sha }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 1
           submodules: false
@@ -323,7 +323,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 1
           submodules: false


### PR DESCRIPTION
Combines the three open Dependabot GitHub Actions bumps into a single PR so that prcheck runs with access to repository secrets (Dependabot-authored PRs run without secret access).

- actions/checkout 6 → 7 (#1120)
- docker/setup-buildx-action 3 → 4 (#1121)
- actions/configure-pages 5 → 6 (#1122)