### PR TITLE
fix(build): bump Hexagon toolchain to v0.7 to fix miscompiled HTP v75…

### DIFF
--- a/.github/docker/toolchain-android.Dockerfile
+++ b/.github/docker/toolchain-android.Dockerfile
@@ -5,16 +5,16 @@
 # bakes in build-essential (for Rust proc-macro host linking), ccache,
 # and the aarch64-linux-android Rust target so _build-sdk.yml can skip
 # the per-run apt-get / rustup installation.
-ARG UPSTREAM_TAG=v0.3
+ARG UPSTREAM_TAG=v0.7
 FROM ghcr.io/snapdragon-toolchain/arm64-android:${UPSTREAM_TAG}
 
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-        build-essential \
-        ccache \
-        ca-certificates \
+    build-essential \
+    ccache \
+    ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
 ENV RUSTUP_HOME=/opt/rust/rustup \
@@ -22,6 +22,6 @@ ENV RUSTUP_HOME=/opt/rust/rustup \
     PATH=/opt/rust/cargo/bin:$PATH
 
 RUN curl --proto "=https" --tlsv1.2 -sSf https://sh.rustup.rs \
-        | sh -s -- -y --default-toolchain stable --profile minimal \
+    | sh -s -- -y --default-toolchain stable --profile minimal \
     && rustup target add aarch64-linux-android \
     && chmod -R a+rwX /opt/rust

--- a/.github/docker/toolchain-linux.Dockerfile
+++ b/.github/docker/toolchain-linux.Dockerfile
@@ -5,7 +5,13 @@
 # This layer bakes in build-essential, ccache, rustup, the aarch64 Rust
 # target, and the cc-rs compatibility symlinks so _build-sdk.yml can skip
 # the per-run apt-get / rustup installation.
-ARG UPSTREAM_TAG=v0.1
+#
+# UPSTREAM_TAG selects the Hexagon SDK / hexagon-clang used to build the
+# HTP DSP kernels (libggml-htp-vNN.so). v0.1 shipped Hexagon SDK 6.4.0.2
+# (tools 19.0.04), which miscompiles the v75 kernel and produces gibberish
+# GGUF output on QCS8275 (Hexagon v75) NPUs. v0.7 (Hexagon SDK 6.6.0.0,
+# tools 19.0.07) builds a correct v75 kernel. Keep this at v0.7+.
+ARG UPSTREAM_TAG=v0.7
 FROM ghcr.io/snapdragon-toolchain/arm64-linux:${UPSTREAM_TAG}
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/.github/docker/toolchain-linux.Dockerfile
+++ b/.github/docker/toolchain-linux.Dockerfile
@@ -5,12 +5,6 @@
 # This layer bakes in build-essential, ccache, rustup, the aarch64 Rust
 # target, and the cc-rs compatibility symlinks so _build-sdk.yml can skip
 # the per-run apt-get / rustup installation.
-#
-# UPSTREAM_TAG selects the Hexagon SDK / hexagon-clang used to build the
-# HTP DSP kernels (libggml-htp-vNN.so). v0.1 shipped Hexagon SDK 6.4.0.2
-# (tools 19.0.04), which miscompiles the v75 kernel and produces gibberish
-# GGUF output on QCS8275 (Hexagon v75) NPUs. v0.7 (Hexagon SDK 6.6.0.0,
-# tools 19.0.07) builds a correct v75 kernel. Keep this at v0.7+.
 ARG UPSTREAM_TAG=v0.7
 FROM ghcr.io/snapdragon-toolchain/arm64-linux:${UPSTREAM_TAG}
 
@@ -18,18 +12,18 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-        build-essential \
-        ccache \
-        make \
-        ca-certificates \
+    build-essential \
+    ccache \
+    make \
+    ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
 # gcc-13 cross: base image's gcc-14 emits CXXABI_1.3.15 which Qualcomm
 # Linux on-device libstdc++ 6.0.32 lacks. See #458.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-        gcc-13-aarch64-linux-gnu \
-        g++-13-aarch64-linux-gnu \
+    gcc-13-aarch64-linux-gnu \
+    g++-13-aarch64-linux-gnu \
     && rm -rf /var/lib/apt/lists/*
 
 ENV RUSTUP_HOME=/opt/rust/rustup \
@@ -37,7 +31,7 @@ ENV RUSTUP_HOME=/opt/rust/rustup \
     PATH=/opt/rust/cargo/bin:$PATH
 
 RUN curl --proto "=https" --tlsv1.2 -sSf https://sh.rustup.rs \
-        | sh -s -- -y --default-toolchain stable --profile minimal \
+    | sh -s -- -y --default-toolchain stable --profile minimal \
     && rustup target add aarch64-unknown-linux-gnu \
     && chmod -R a+rwX /opt/rust
 
@@ -45,6 +39,6 @@ RUN curl --proto "=https" --tlsv1.2 -sSf https://sh.rustup.rs \
 # but Debian ships them as aarch64-linux-gnu-*. Symlink so onig_sys (via
 # tokenizers-cpp) cross-compiles without ToolNotFound.
 RUN for tool in gcc g++ ar; do \
-        ln -sf "/usr/bin/aarch64-linux-gnu-${tool}" \
-               "/usr/local/bin/aarch64-unknown-linux-gnu-${tool}"; \
+    ln -sf "/usr/bin/aarch64-linux-gnu-${tool}" \
+    "/usr/local/bin/aarch64-unknown-linux-gnu-${tool}"; \
     done

--- a/.github/workflows/_build-sdk.yml
+++ b/.github/workflows/_build-sdk.yml
@@ -40,16 +40,11 @@ jobs:
           - platform: linux-arm64
             runner: ubuntu-latest
             preset: arm64-linux-snapdragon-release
-            # v0.1.0 rebuilds the derived image from toolchain-linux.Dockerfile
-            # with UPSTREAM_TAG=v0.7 (Hexagon SDK 6.6.0.0). The prior v0.0.1 was
-            # built on Hexagon SDK 6.4.0.2, which miscompiled libggml-htp-v75.so
-            # and produced gibberish GGUF output on QCS8275 NPUs. Rebuild and
-            # publish geniex-toolchain-linux:v0.1.0 before this pin takes effect.
             container_image: docker.io/qualcomm/geniex-toolchain-linux:v0.1.0
           - platform: android-arm64
             runner: ubuntu-latest
             preset: arm64-android-snapdragon-release
-            container_image: docker.io/qualcomm/geniex-toolchain-android:v0.0.1
+            container_image: docker.io/qualcomm/geniex-toolchain-android:v0.1.0
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 120
 

--- a/.github/workflows/_build-sdk.yml
+++ b/.github/workflows/_build-sdk.yml
@@ -40,7 +40,12 @@ jobs:
           - platform: linux-arm64
             runner: ubuntu-latest
             preset: arm64-linux-snapdragon-release
-            container_image: docker.io/qualcomm/geniex-toolchain-linux:v0.0.1
+            # v0.1.0 rebuilds the derived image from toolchain-linux.Dockerfile
+            # with UPSTREAM_TAG=v0.7 (Hexagon SDK 6.6.0.0). The prior v0.0.1 was
+            # built on Hexagon SDK 6.4.0.2, which miscompiled libggml-htp-v75.so
+            # and produced gibberish GGUF output on QCS8275 NPUs. Rebuild and
+            # publish geniex-toolchain-linux:v0.1.0 before this pin takes effect.
+            container_image: docker.io/qualcomm/geniex-toolchain-linux:v0.1.0
           - platform: android-arm64
             runner: ubuntu-latest
             preset: arm64-android-snapdragon-release


### PR DESCRIPTION
… kernel

The linux SDK toolchain image was built FROM snapdragon-toolchain/arm64-linux:v0.1 (Hexagon SDK 6.4.0.2), which miscompiles libggml-htp-v75.so. On QCS8275 (which loads the v75 DSP kernel) this produces gibberish GGUF output on the NPU, while CPU/GPU paths and QAIRT are unaffected. Rebuilding the v75 kernel with the v0.7 toolchain (Hexagon SDK 6.6.0.0) yields correct output, verified by swapping the kernel into the shipped qualcomm/geniex image.

- toolchain-linux.Dockerfile: UPSTREAM_TAG v0.1 -> v0.7
- _build-sdk.yml: pin geniex-toolchain-linux:v0.1.0 (rebuilt derived image)