### PR TITLE
fix(python): fix VLM multi-turn image guard and test message order

### DIFF
--- a/bindings/python/geniex/modeling.py
+++ b/bindings/python/geniex/modeling.py
@@ -319,15 +319,16 @@ class GenieXLLM:
 
 
 def _messages_have_modality(messages: list[dict], modality: str) -> bool:
-    # True if any message's content list contains a block with the given
-    # ``type`` (e.g. 'image' / 'audio'). Plain string content trivially
-    # holds none.
-    for msg in messages:
+    # True if the last user message contains a content block with the given
+    # ``type`` (e.g. 'image' / 'audio'). Only the current turn is checked:
+    # prior-turn media is already in the KV cache and must not be re-supplied.
+    for msg in reversed(messages):
+        if msg.get('role') != 'user':
+            continue
         content = msg.get('content')
         if isinstance(content, list):
-            for item in content:
-                if isinstance(item, dict) and item.get('type') == modality:
-                    return True
+            return any(isinstance(item, dict) and item.get('type') == modality for item in content)
+        return False
     return False
 
 

--- a/bindings/python/tests/unit/test_error_messages.py
+++ b/bindings/python/tests/unit/test_error_messages.py
@@ -212,6 +212,46 @@ def test_messages_have_modality_audio():
     assert _messages_have_modality(msgs, 'audio') is True
 
 
+def test_messages_have_modality_ignores_prior_turns():
+    # Multi-turn VLM: the current turn is text-only, so generate() must
+    # not be gated on the image block from an earlier turn -- prior-turn
+    # media is already in the KV cache and must not be re-supplied.
+    msgs = [
+        {
+            'role': 'user',
+            'content': [
+                {'type': 'image', 'image': '/cat.png'},
+                {'type': 'text', 'text': 'describe'},
+            ],
+        },
+        {'role': 'assistant', 'content': 'a cat on a mat'},
+        {'role': 'user', 'content': 'what color?'},
+    ]
+    assert _messages_have_modality(msgs, 'image') is False
+    assert _messages_have_modality(msgs, 'audio') is False
+
+
+def test_messages_have_modality_detects_current_turn():
+    # Same shape as above but the *current* turn references an image ->
+    # generate() must still fire the "pass images=[...]" guard.
+    msgs = [
+        {'role': 'user', 'content': 'hello'},
+        {'role': 'assistant', 'content': 'hi'},
+        {
+            'role': 'user',
+            'content': [
+                {'type': 'image', 'image': '/dog.png'},
+                {'type': 'text', 'text': 'describe'},
+            ],
+        },
+    ]
+    assert _messages_have_modality(msgs, 'image') is True
+
+
+def test_messages_have_modality_empty():
+    assert _messages_have_modality([], 'image') is False
+
+
 # ---------------------------------------------------------------------------
 # #726 / #727: VLM.generate predicates can be unit-tested via a stub
 # ---------------------------------------------------------------------------

--- a/tests/plugins/llama_cpp/test_llama_cpp_vlm.py
+++ b/tests/plugins/llama_cpp/test_llama_cpp_vlm.py
@@ -26,8 +26,8 @@ def _vlm_prompt(vlm: geniex.GenieXVLM, image_path: str, text: str) -> str:
             {
                 'role': 'user',
                 'content': [
-                    {'type': 'image', 'image': image_path},
                     {'type': 'text', 'text': text},
+                    {'type': 'image', 'image': image_path},
                 ],
             }
         ],


### PR DESCRIPTION
Closes #1131

## What

Two `test-sdk-qdc / llama_cpp_vlm` failures on X Elite Windows (CI run 28492301153):

**`test_multi_turn_without_reset`** — raised `ValueError: messages reference image content but generate(images=[...]) is empty`. `_messages_have_modality` scanned the entire conversation history; the second turn passed the full history (containing the first-turn image block) to `apply_chat_template`, setting `_last_template_has_image=True`. The guard then blocked `generate(images=[])`, which is the correct call for a follow-up turn whose image is already in the KV cache.

**`test_quality_keywords[npu]`** — image content order in `_vlm_prompt` was `[image, text]`. The C SDK reference (`build_vlm_prompt` in benchmark.c, PR #1112) uses `[text, image]` order.

## Changes

- `modeling.py`: `_messages_have_modality` now checks only the last user message instead of the full history. Prior-turn media is already in the KV cache and must not be re-supplied.
- `test_llama_cpp_vlm.py`: align `_vlm_prompt` content order to `[text, image]`, matching `build_vlm_prompt` in benchmark.c.
- `test_error_messages.py`: three unit regressions covering the modality-scope fix (ignore prior turns, detect current turn, empty list).
