### PR TITLE
fix(python): scope VLM modality check to the current turn

### DIFF
--- a/bindings/python/geniex/modeling.py
+++ b/bindings/python/geniex/modeling.py
@@ -330,15 +330,21 @@ class GenieXLLM:
 
 
 def _messages_have_modality(messages: list[dict], modality: str) -> bool:
-    # True if any message's content list contains a block with the given
-    # ``type`` (e.g. 'image' / 'audio'). Plain string content trivially
-    # holds none.
-    for msg in messages:
-        content = msg.get('content')
-        if isinstance(content, list):
-            for item in content:
-                if isinstance(item, dict) and item.get('type') == modality:
-                    return True
+    # True if the LAST message's content list contains a block with the
+    # given ``type`` (e.g. 'image' / 'audio'). Only the last turn matters
+    # here: generate(images=[...]) supplies the paths for the current
+    # turn, and stale image/audio blocks in prior turns must not gate it
+    # (see Go CLI / server behaviour in cli/cmd/geniex/infer.go and
+    # cli/server/handler/chat.go). Plain string content trivially holds
+    # none.
+    if not messages:
+        return False
+    content = messages[-1].get('content')
+    if not isinstance(content, list):
+        return False
+    for item in content:
+        if isinstance(item, dict) and item.get('type') == modality:
+            return True
     return False
 
 

--- a/bindings/python/tests/unit/test_error_messages.py
+++ b/bindings/python/tests/unit/test_error_messages.py
@@ -223,6 +223,47 @@ def test_messages_have_modality_audio():
     assert _messages_have_modality(msgs, 'audio') is True
 
 
+def test_messages_have_modality_ignores_prior_turns():
+    # Multi-turn VLM: the current turn is text-only, so generate() must
+    # not be gated on the image block from an earlier turn. Go CLI /
+    # server extract media only from the last message; Python mirrors
+    # that here.
+    msgs = [
+        {
+            'role': 'user',
+            'content': [
+                {'type': 'image', 'image': '/cat.png'},
+                {'type': 'text', 'text': 'describe'},
+            ],
+        },
+        {'role': 'assistant', 'content': 'a cat on a mat'},
+        {'role': 'user', 'content': 'what color?'},
+    ]
+    assert _messages_have_modality(msgs, 'image') is False
+    assert _messages_have_modality(msgs, 'audio') is False
+
+
+def test_messages_have_modality_detects_current_turn():
+    # Same shape as above but the *current* turn references an image ->
+    # generate() must still fire the "pass images=[...]" guard.
+    msgs = [
+        {'role': 'user', 'content': 'hello'},
+        {'role': 'assistant', 'content': 'hi'},
+        {
+            'role': 'user',
+            'content': [
+                {'type': 'image', 'image': '/dog.png'},
+                {'type': 'text', 'text': 'describe'},
+            ],
+        },
+    ]
+    assert _messages_have_modality(msgs, 'image') is True
+
+
+def test_messages_have_modality_empty():
+    assert _messages_have_modality([], 'image') is False
+
+
 # ---------------------------------------------------------------------------
 # #726 / #727: VLM.generate predicates can be unit-tested via a stub
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1131

## Summary

`_messages_have_modality` walked the full chat history when deciding whether the pre-`generate()` guard should fire; it now inspects only the last message, matching how the Go CLI / server extract media (only from the current turn).

## Test plan

- [x] `_messages_have_modality` returns `False` when only *prior* turns hold `{type: image}` / `{type: audio}` blocks and the current turn is text-only (new `test_messages_have_modality_ignores_prior_turns`)
- [x] `_messages_have_modality` still fires on the current turn's media block (new `test_messages_have_modality_detects_current_turn`)
- [x] `_messages_have_modality([], modality)` returns `False` (new `test_messages_have_modality_empty`)
- [x] `pytest bindings/python/tests/unit/test_error_messages.py -q` → 25 passed