### PR TITLE
chore(sdk): bump pinned aihm release to v0.57.0

### DIFF
--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -28,7 +28,7 @@ const DefaultAIHubBaseURL = "https://qaihub-public-assets.s3.us-west-2.amazonaws
 // DefaultAIHubVersion is the pinned aihm release the CLI consumes. The public
 // bucket has no `latest` alias; manifests are only at
 // <base>/releases/<version>/manifest.json. Override via GENIEX_AIHUBVERSION.
-const DefaultAIHubVersion = "v0.55.0"
+const DefaultAIHubVersion = "v0.57.0"
 
 type Config struct {
 	// Global settings

--- a/sdk/model-manager/crates/core/src/config.rs
+++ b/sdk/model-manager/crates/core/src/config.rs
@@ -70,7 +70,7 @@ const DEFAULT_AI_HUB_BASE_URL: &str =
     "https://qaihub-public-assets.s3.us-west-2.amazonaws.com/qai-hub-models";
 
 /// Mirrors `cli/internal/config/config.go:DefaultAIHubVersion`.
-const DEFAULT_AI_HUB_VERSION: &str = "v0.55.0";
+const DEFAULT_AI_HUB_VERSION: &str = "v0.57.0";
 
 fn default_data_dir() -> PathBuf {
     let home = std::env::var("HOME")

--- a/sdk/model-manager/crates/core/tests/ai_hub_live.rs
+++ b/sdk/model-manager/crates/core/tests/ai_hub_live.rs
@@ -25,7 +25,7 @@ use model_manager_core::transport::ReqwestTransport;
 
 const AI_HUB_BASE_URL: &str =
     "https://qaihub-public-assets.s3.us-west-2.amazonaws.com/qai-hub-models";
-const AI_HUB_VERSION: &str = "v0.55.0";
+const AI_HUB_VERSION: &str = "v0.57.0";
 
 const PHI_DISPLAY_NAME: &str = "Phi-3.5-Mini-Instruct";
 const PHI_CHIPSET: &str = "qualcomm-snapdragon-x-elite";


### PR DESCRIPTION
## Summary
- Bump the pinned Qualcomm AI Hub (`ai-hub-models` / aihm) release consumed for QAIRT model artifacts from `v0.55.0` to `v0.57.0`, in both the Go CLI default and the Rust SDK model-manager default (kept in sync per their existing mirroring comments).
- Also bump the version pin used by the SDK's `ai_hub_live` integration test, which targets the real public bucket independently of the runtime default.

## Test plan
- [x] Manually verified `v0.57.0` pulls a QAIRT model successfully via `GENIEX_AIHUBVERSION=v0.57.0 geniex model pull <model>` against the live S3 bucket.
- [ ] CI lint/build.