### PR TITLE
ci(release): publish stable tags to production PyPI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -416,9 +416,11 @@ jobs:
       tag: ${{ needs.resolve-tag.outputs.tag }}
       is_prerelease: ${{ needs.resolve-tag.outputs.is_prerelease == 'true' }}
 
+  # Prerelease (hyphen-bearing) tags go to TestPyPI.
   publish-testpypi:
     name: publish-testpypi
     needs: [resolve-tag, build-python-sdist]
+    if: needs.resolve-tag.outputs.is_prerelease == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -432,6 +434,28 @@ jobs:
         with:
           repository-url: https://test.pypi.org/legacy/
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          packages-dir: dist/
+          skip-existing: true
+          # API-token auth, not Trusted Publishing — attestations are a no-op.
+          attestations: false
+
+  # Stable (bare vX.Y.Z) tags publish to production PyPI.
+  publish-pypi:
+    name: publish-pypi
+    needs: [resolve-tag, build-python-sdist]
+    if: needs.resolve-tag.outputs.is_prerelease != 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: python-sdist
+          path: dist/
+
+      - name: Publish sdist to PyPI
+        uses: pypa/gh-action-pypi-publish@v1.14.0
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
           packages-dir: dist/
           skip-existing: true
           # API-token auth, not Trusted Publishing — attestations are a no-op.
@@ -545,5 +569,4 @@ jobs:
           [ "$http_code" = "201" ] || { echo "::error::Upload failed (HTTP ${http_code})"; exit 1; }
           echo "::notice::Deployment uploaded. Validate + click Publish at https://central.sonatype.com/publishing/deployments"
 
-  # TODO: production PyPI publish for stable tags (needs Trusted Publishing).
   # TODO: winget manifest submission for the Windows installer.

--- a/notes/release.md
+++ b/notes/release.md
@@ -7,7 +7,7 @@ git tag v1.2.3 && git push origin v1.2.3
 ```
 
 - Tags containing `-` are drafts (and push the sdist to TestPyPI).
-- Bare `vX.Y.Z` tags publish immediately.
+- Bare `vX.Y.Z` tags publish immediately (and push the sdist to production PyPI).
 - Assets: `geniex-sdk-{linux,windows}-arm64-<tag>.zip`, `geniex-cli-linux-arm64-<tag>.tar.gz`, `geniex-cli-setup-windows-arm64-<tag>.exe`, `*.whl`, `*.aar`, and per-file `.sha256` sidecars.
 - Re-running the same tag via **Actions → Release → Run workflow** is safe **as long as you set "Use workflow from" to the tag** (Tags tab in the dropdown). Dispatching from `main` is rejected by `resolve-tag` so the workflow never builds a tag against the wrong commit.
 - S3 mirror at `s3://qaihub-public-assets/qai-hub-geniex/` — see [§ S3 mirror & manifest](#s3-mirror--manifest) below.
@@ -99,7 +99,7 @@ All objects live directly under the prefix — no `<tag>/` subdirectories. The `
 | `index.json` | every tag | `no-cache` | Full version catalogue |
 | `latest.json` | stable only | `no-cache` | Pointer to the latest stable manifest |
 
-Other assets (AAR, sdist, HTP cert/to-sign zips) ship via GitHub Releases / Maven Central / TestPyPI only — not via S3.
+Other assets (AAR, sdist, HTP cert/to-sign zips) ship via GitHub Releases / Maven Central / PyPI (stable) / TestPyPI (prerelease) only — not via S3.
 
 ### Manifest contract for client apps
 


### PR DESCRIPTION
## What

Split Python package publishing by release channel in `release.yml`:

- **Stable tags** (bare `vX.Y.Z`) → **production PyPI** via a new `publish-pypi` job. Auth uses a new repo secret **`PYPI_API_TOKEN`**.
- **Prerelease tags** (hyphen-bearing: alpha/beta/rc) → **TestPyPI**, unchanged endpoint/secret. `publish-testpypi` is now gated with `if: is_prerelease == 'true'` (previously it ran for *all* tags).
- Removed the stale `# TODO: production PyPI publish for stable tags` comment; updated `notes/release.md`.

Both jobs upload all three sdists: `geniex`, `geniex-llama-cpp`, `geniex-qairt`.

## Why

Prereleases should stay on the staging index; only stable versions belong on production PyPI. This mirrors the stable-only / staging split already used for Maven Central.

## Reviewer call-outs

- **New secret required:** `PYPI_API_TOKEN` must be set in repo secrets before the next stable tag, or `publish-pypi` fails. TestPyPI keeps using `TEST_PYPI_API_TOKEN`.
- Kept API-token auth (not Trusted Publishing) to match the existing TestPyPI job; `attestations: false`.
- `skip-existing: true` so re-running an already-published stable tag won't hard-fail on PyPI's immutable (project, version).