### PR TITLE
chore: add BSD-3-Clause SPDX headers to satisfy Repolinter

### DIFF
--- a/.github/scripts/release.js
+++ b/.github/scripts/release.js
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 module.exports = async ({ github, context, core }) => {
   const { VERSION, FILES, HTP_SIGNED, LLAMA_SHA } = process.env;
   const owner = context.repo.owner;

--- a/bindings/go/common.go
+++ b/bindings/go/common.go
@@ -1,16 +1,5 @@
 // Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: BSD-3-Clause
 
 package geniex_sdk
 

--- a/bindings/go/common_test.go
+++ b/bindings/go/common_test.go
@@ -1,16 +1,5 @@
 // Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: BSD-3-Clause
 
 package geniex_sdk
 

--- a/bindings/go/device.go
+++ b/bindings/go/device.go
@@ -1,16 +1,5 @@
 // Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: BSD-3-Clause
 
 package geniex_sdk
 

--- a/bindings/go/helpers.go
+++ b/bindings/go/helpers.go
@@ -1,16 +1,5 @@
 // Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: BSD-3-Clause
 
 package geniex_sdk
 

--- a/bindings/go/llm.go
+++ b/bindings/go/llm.go
@@ -1,16 +1,5 @@
 // Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: BSD-3-Clause
 
 package geniex_sdk
 

--- a/bindings/go/ml.go
+++ b/bindings/go/ml.go
@@ -1,16 +1,5 @@
 // Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: BSD-3-Clause
 
 package geniex_sdk
 

--- a/bindings/go/model_manager.go
+++ b/bindings/go/model_manager.go
@@ -1,16 +1,5 @@
 // Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: BSD-3-Clause
 
 package geniex_sdk
 

--- a/bindings/go/vlm.go
+++ b/bindings/go/vlm.go
@@ -1,16 +1,5 @@
 // Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: BSD-3-Clause
 
 package geniex_sdk
 

--- a/bindings/python-llama-cpp/setup.py
+++ b/bindings/python-llama-cpp/setup.py
@@ -1,10 +1,5 @@
 # Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Setuptools driver for the ``geniex-llama-cpp`` sibling sdist.
 

--- a/bindings/python-qairt/setup.py
+++ b/bindings/python-qairt/setup.py
@@ -1,10 +1,5 @@
 # Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Setuptools driver for the ``geniex-qairt`` sibling sdist.
 

--- a/bindings/python/_geniex_backend.py
+++ b/bindings/python/_geniex_backend.py
@@ -1,10 +1,5 @@
 # Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
+# SPDX-License-Identifier: BSD-3-Clause
 
 """PEP 517 wrapper around setuptools.build_meta.
 

--- a/bindings/python/_sdk_fetch.py
+++ b/bindings/python/_sdk_fetch.py
@@ -1,10 +1,5 @@
 # Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Install-time SDK fetcher.
 

--- a/bindings/python/_shared_setup.py
+++ b/bindings/python/_shared_setup.py
@@ -1,10 +1,5 @@
 # Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Shared driver for the three sibling sdists (#554).
 

--- a/bindings/python/geniex/__init__.py
+++ b/bindings/python/geniex/__init__.py
@@ -1,16 +1,5 @@
 # Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: BSD-3-Clause
 
 from . import model_manager
 from ._ffi._api import (

--- a/bindings/python/geniex/_ffi/__init__.py
+++ b/bindings/python/geniex/_ffi/__init__.py
@@ -1,16 +1,5 @@
 # Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: BSD-3-Clause
 
 from ._api import (
     GenieXError,

--- a/bindings/python/geniex/_ffi/_api.py
+++ b/bindings/python/geniex/_ffi/_api.py
@@ -1,16 +1,5 @@
 # Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Bound C functions from libgeniex with argtypes/restype annotations."""
 

--- a/bindings/python/geniex/_ffi/_lib.py
+++ b/bindings/python/geniex/_ffi/_lib.py
@@ -1,16 +1,5 @@
 # Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Native library loader. Search order: ``GENIEX_LIB_PATH`` → wheel layout → in-tree dev build → OS linker."""
 

--- a/bindings/python/geniex/_ffi/_types.py
+++ b/bindings/python/geniex/_ffi/_types.py
@@ -1,16 +1,5 @@
 # Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """ctypes struct/type definitions mirroring sdk/include/geniex.h."""
 

--- a/bindings/python/geniex/_progress.py
+++ b/bindings/python/geniex/_progress.py
@@ -1,16 +1,5 @@
 # Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Default progress rendering for model downloads.
 

--- a/bindings/python/geniex/_version.py
+++ b/bindings/python/geniex/_version.py
@@ -1,1 +1,4 @@
+# Copyright (c) 2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+
 __version__ = '0.1.0'

--- a/bindings/python/geniex/auto.py
+++ b/bindings/python/geniex/auto.py
@@ -1,16 +1,5 @@
 # Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """AutoModelForCausalLM and AutoModelForVision2Seq factory classes."""
 

--- a/bindings/python/geniex/cli.py
+++ b/bindings/python/geniex/cli.py
@@ -1,16 +1,5 @@
 # Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """geniex-py console-script entry point.
 

--- a/bindings/python/geniex/generation/__init__.py
+++ b/bindings/python/geniex/generation/__init__.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+
 from .config import GenerationConfig
 from .output import GenerateOutput, ProfileData
 from .streamer import TextIteratorStreamer

--- a/bindings/python/geniex/generation/config.py
+++ b/bindings/python/geniex/generation/config.py
@@ -1,16 +1,5 @@
 # Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: BSD-3-Clause
 
 from __future__ import annotations
 

--- a/bindings/python/geniex/generation/output.py
+++ b/bindings/python/geniex/generation/output.py
@@ -1,16 +1,5 @@
 # Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: BSD-3-Clause
 
 from __future__ import annotations
 

--- a/bindings/python/geniex/generation/streamer.py
+++ b/bindings/python/geniex/generation/streamer.py
@@ -1,16 +1,5 @@
 # Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: BSD-3-Clause
 
 from __future__ import annotations
 

--- a/bindings/python/geniex/model_manager.py
+++ b/bindings/python/geniex/model_manager.py
@@ -1,16 +1,5 @@
 # Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """High-level Python API for the geniex model manager."""
 

--- a/bindings/python/geniex/modeling.py
+++ b/bindings/python/geniex/modeling.py
@@ -1,16 +1,5 @@
 # Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: BSD-3-Clause
 
 from __future__ import annotations
 

--- a/bindings/python/geniex/tokenizer.py
+++ b/bindings/python/geniex/tokenizer.py
@@ -1,16 +1,5 @@
 # Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: BSD-3-Clause
 
 from __future__ import annotations
 

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -1,10 +1,5 @@
 # Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Setuptools driver for the meta ``geniex`` sdist (both backends).
 

--- a/bindings/python/tests/__init__.py
+++ b/bindings/python/tests/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) 2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+

--- a/bindings/python/tests/conftest.py
+++ b/bindings/python/tests/conftest.py
@@ -1,16 +1,5 @@
 # Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Fixtures for the Python binding contract tests.
 

--- a/bindings/python/tests/test_cli.py
+++ b/bindings/python/tests/test_cli.py
@@ -1,16 +1,5 @@
 # Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Contract tests for the geniex-py CLI.
 

--- a/bindings/python/tests/test_local_aihub_pull.py
+++ b/bindings/python/tests/test_local_aihub_pull.py
@@ -1,16 +1,5 @@
 # Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Local AI Hub pull (extracted directory + local zip) — public API.
 

--- a/bindings/python/tests/test_model_manager.py
+++ b/bindings/python/tests/test_model_manager.py
@@ -1,16 +1,5 @@
 # Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Model manager public API — exercises real HuggingFace pulls."""
 

--- a/bindings/python/tests/test_progress.py
+++ b/bindings/python/tests/test_progress.py
@@ -1,16 +1,5 @@
 # Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Unit tests for the tqdm-backed download progress printer."""
 

--- a/bindings/python/tests/unit/test_cli_load_banner.py
+++ b/bindings/python/tests/unit/test_cli_load_banner.py
@@ -1,16 +1,5 @@
 # Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Unit coverage for the #763 _cmd_chat load-banner: it must read plugin/device
 from ``model._meta`` instead of calling ``resolve_device_map`` a second time."""

--- a/bindings/python/tests/unit/test_default_precision.py
+++ b/bindings/python/tests/unit/test_default_precision.py
@@ -1,16 +1,5 @@
 # Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Unit tests for the ensure_cached default-precision resolution (#1098).
 

--- a/bindings/python/tests/unit/test_error_messages.py
+++ b/bindings/python/tests/unit/test_error_messages.py
@@ -1,16 +1,5 @@
 # Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Pure-Python unit coverage for the dogfood error-message and profile
 metadata fixes (issues #715, #725, #726, #727, #736, #739).

--- a/bindings/python/tests/unit/test_modeling_decode.py
+++ b/bindings/python/tests/unit/test_modeling_decode.py
@@ -1,16 +1,5 @@
 # Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Unit coverage for the lenient UTF-8 decode helper that backs LLM/VLM
 generate output. Regression for #888: a generation truncated at

--- a/bindings/python/tests/unit/test_qairt_coerce.py
+++ b/bindings/python/tests/unit/test_qairt_coerce.py
@@ -1,16 +1,5 @@
 # Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Unit coverage for the QAIRT n_ctx / n_gpu_layers coercion path in #763."""
 

--- a/bindings/python/tests/unit/test_quant_validation.py
+++ b/bindings/python/tests/unit/test_quant_validation.py
@@ -1,16 +1,5 @@
 # Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Unit coverage for the #737 quant-validation translator.
 

--- a/bindings/python/tests/unit/test_sdk_fetch.py
+++ b/bindings/python/tests/unit/test_sdk_fetch.py
@@ -1,10 +1,5 @@
 # Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Tests for ``_sdk_fetch.py`` — the install-time SDK fetcher (#554).
 

--- a/bindings/sync_siblings.py
+++ b/bindings/sync_siblings.py
@@ -1,11 +1,6 @@
 #!/usr/bin/env python3
 # Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Mirror the canonical Python sources from ``bindings/python/`` into the
 sibling sdist trees ``bindings/python-llama-cpp/`` and ``bindings/python-qairt/``,

--- a/cli/cmd/geniex/common/console_other.go
+++ b/cli/cmd/geniex/common/console_other.go
@@ -1,16 +1,5 @@
 // Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: BSD-3-Clause
 
 //go:build !windows
 

--- a/cli/cmd/geniex/common/console_windows.go
+++ b/cli/cmd/geniex/common/console_windows.go
@@ -1,16 +1,5 @@
 // Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: BSD-3-Clause
 
 package common
 

--- a/cli/cmd/geniex/common/error.go
+++ b/cli/cmd/geniex/common/error.go
@@ -1,16 +1,5 @@
 // Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: BSD-3-Clause
 
 package common
 

--- a/cli/cmd/geniex/common/log.go
+++ b/cli/cmd/geniex/common/log.go
@@ -1,16 +1,5 @@
 // Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: BSD-3-Clause
 
 package common
 

--- a/cli/cmd/geniex/common/process.go
+++ b/cli/cmd/geniex/common/process.go
@@ -1,16 +1,5 @@
 // Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: BSD-3-Clause
 
 package common
 

--- a/cli/cmd/geniex/common/process_test.go
+++ b/cli/cmd/geniex/common/process_test.go
@@ -1,16 +1,5 @@
 // Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: BSD-3-Clause
 
 package common
 

--- a/cli/cmd/geniex/common/repl.go
+++ b/cli/cmd/geniex/common/repl.go
@@ -1,16 +1,5 @@
 // Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: BSD-3-Clause
 
 package common
 

--- a/cli/cmd/geniex/common/util_linux.go
+++ b/cli/cmd/geniex/common/util_linux.go
@@ -1,16 +1,5 @@
 // Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: BSD-3-Clause
 
 package common
 

--- a/cli/cmd/geniex/common/util_windows.go
+++ b/cli/cmd/geniex/common/util_windows.go
@@ -1,16 +1,5 @@
 // Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: BSD-3-Clause
 
 package common
 

--- a/cli/cmd/geniex/config.go
+++ b/cli/cmd/geniex/config.go
@@ -1,16 +1,5 @@
 // Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: BSD-3-Clause
 
 package main
 

--- a/cli/cmd/geniex/help.go
+++ b/cli/cmd/geniex/help.go
@@ -1,16 +1,5 @@
 // Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: BSD-3-Clause
 
 package main
 

--- a/cli/cmd/geniex/infer.go
+++ b/cli/cmd/geniex/infer.go
@@ -1,16 +1,5 @@
 // Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: BSD-3-Clause
 
 package main
 

--- a/cli/cmd/geniex/main.go
+++ b/cli/cmd/geniex/main.go
@@ -1,16 +1,5 @@
 // Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: BSD-3-Clause
 
 package main
 

--- a/cli/cmd/geniex/model.go
+++ b/cli/cmd/geniex/model.go
@@ -1,16 +1,5 @@
 // Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: BSD-3-Clause
 
 package main
 

--- a/cli/cmd/geniex/model_test.go
+++ b/cli/cmd/geniex/model_test.go
@@ -1,16 +1,5 @@
 // Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: BSD-3-Clause
 
 package main
 

--- a/cli/cmd/geniex/run.go
+++ b/cli/cmd/geniex/run.go
@@ -1,16 +1,5 @@
 // Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: BSD-3-Clause
 
 package main
 

--- a/cli/cmd/geniex/serve.go
+++ b/cli/cmd/geniex/serve.go
@@ -1,16 +1,5 @@
 // Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: BSD-3-Clause
 
 package main
 

--- a/cli/cmd/geniex/update.go
+++ b/cli/cmd/geniex/update.go
@@ -1,16 +1,5 @@
 // Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: BSD-3-Clause
 
 package main
 

--- a/cli/cmd/geniex/update_test.go
+++ b/cli/cmd/geniex/update_test.go
@@ -1,16 +1,5 @@
 // Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: BSD-3-Clause
 
 package main
 

--- a/cli/cmd/geniex/version.go
+++ b/cli/cmd/geniex/version.go
@@ -1,16 +1,5 @@
 // Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: BSD-3-Clause
 
 package main
 

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -1,16 +1,5 @@
 // Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: BSD-3-Clause
 
 package config
 

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -1,16 +1,5 @@
 // Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: BSD-3-Clause
 
 package config
 

--- a/cli/internal/downloader/http.go
+++ b/cli/internal/downloader/http.go
@@ -1,16 +1,5 @@
 // Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: BSD-3-Clause
 
 package downloader
 

--- a/cli/internal/downloader/http_test.go
+++ b/cli/internal/downloader/http_test.go
@@ -1,16 +1,5 @@
 // Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: BSD-3-Clause
 
 package downloader
 

--- a/cli/internal/readline/action.go
+++ b/cli/internal/readline/action.go
@@ -1,16 +1,5 @@
 // Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: BSD-3-Clause
 
 package readline
 

--- a/cli/internal/readline/buffer.go
+++ b/cli/internal/readline/buffer.go
@@ -1,16 +1,5 @@
 // Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: BSD-3-Clause
 
 package readline
 

--- a/cli/internal/readline/history.go
+++ b/cli/internal/readline/history.go
@@ -1,16 +1,5 @@
 // Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: BSD-3-Clause
 
 package readline
 

--- a/cli/internal/readline/package_test.go
+++ b/cli/internal/readline/package_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 package readline
 
 import "testing"

--- a/cli/internal/readline/readline.go
+++ b/cli/internal/readline/readline.go
@@ -1,16 +1,5 @@
 // Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: BSD-3-Clause
 
 package readline
 

--- a/cli/internal/readline/terminal.go
+++ b/cli/internal/readline/terminal.go
@@ -1,16 +1,5 @@
 // Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: BSD-3-Clause
 
 package readline
 

--- a/cli/internal/readline/terminal_linux.go
+++ b/cli/internal/readline/terminal_linux.go
@@ -1,16 +1,5 @@
 // Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: BSD-3-Clause
 
 package readline
 

--- a/cli/internal/readline/terminal_windows.go
+++ b/cli/internal/readline/terminal_windows.go
@@ -1,16 +1,5 @@
 // Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: BSD-3-Clause
 
 package readline
 

--- a/cli/internal/record/package_test.go
+++ b/cli/internal/record/package_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 package record
 
 import "testing"

--- a/cli/internal/record/record.go
+++ b/cli/internal/record/record.go
@@ -1,16 +1,5 @@
 // Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: BSD-3-Clause
 
 package record
 

--- a/cli/internal/record/stream_record.go
+++ b/cli/internal/record/stream_record.go
@@ -1,16 +1,5 @@
 // Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: BSD-3-Clause
 
 package record
 

--- a/cli/internal/render/progressbar.go
+++ b/cli/internal/render/progressbar.go
@@ -1,16 +1,5 @@
 // Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: BSD-3-Clause
 
 package render
 

--- a/cli/internal/render/spinner.go
+++ b/cli/internal/render/spinner.go
@@ -1,16 +1,5 @@
 // Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: BSD-3-Clause
 
 package render
 

--- a/cli/internal/render/theme.go
+++ b/cli/internal/render/theme.go
@@ -1,16 +1,5 @@
 // Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: BSD-3-Clause
 
 package render
 

--- a/cli/internal/render/theme_test.go
+++ b/cli/internal/render/theme_test.go
@@ -1,16 +1,5 @@
 // Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: BSD-3-Clause
 
 package render
 

--- a/cli/internal/store/config.go
+++ b/cli/internal/store/config.go
@@ -1,16 +1,5 @@
 // Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: BSD-3-Clause
 
 package store
 

--- a/cli/internal/store/manager.go
+++ b/cli/internal/store/manager.go
@@ -1,16 +1,5 @@
 // Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: BSD-3-Clause
 
 package store
 

--- a/cli/internal/store/package_test.go
+++ b/cli/internal/store/package_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 package store
 
 import "testing"

--- a/cli/internal/testutil/capture.go
+++ b/cli/internal/testutil/capture.go
@@ -1,16 +1,5 @@
 // Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: BSD-3-Clause
 
 // Package testutil hosts shared helpers used only by *_test.go files.
 package testutil

--- a/cli/server/docs/package_test.go
+++ b/cli/server/docs/package_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 package docs
 
 import "testing"

--- a/cli/server/docs/swagger.go
+++ b/cli/server/docs/swagger.go
@@ -1,16 +1,5 @@
 // Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: BSD-3-Clause
 
 package docs
 

--- a/cli/server/handler/chat.go
+++ b/cli/server/handler/chat.go
@@ -1,16 +1,5 @@
 // Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: BSD-3-Clause
 
 package handler
 

--- a/cli/server/handler/model.go
+++ b/cli/server/handler/model.go
@@ -1,16 +1,5 @@
 // Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: BSD-3-Clause
 
 package handler
 

--- a/cli/server/handler/package_test.go
+++ b/cli/server/handler/package_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 package handler
 
 import "testing"

--- a/cli/server/middleware/auth.go
+++ b/cli/server/middleware/auth.go
@@ -1,15 +1,4 @@
 // Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: BSD-3-Clause
 
 package middleware

--- a/cli/server/middleware/cors.go
+++ b/cli/server/middleware/cors.go
@@ -1,16 +1,5 @@
 // Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: BSD-3-Clause
 
 package middleware
 

--- a/cli/server/middleware/gil.go
+++ b/cli/server/middleware/gil.go
@@ -1,16 +1,5 @@
 // Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: BSD-3-Clause
 
 package middleware
 

--- a/cli/server/middleware/package_test.go
+++ b/cli/server/middleware/package_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 package middleware
 
 import "testing"

--- a/cli/server/package_test.go
+++ b/cli/server/package_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 package server
 
 import "testing"

--- a/cli/server/route.go
+++ b/cli/server/route.go
@@ -1,16 +1,5 @@
 // Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: BSD-3-Clause
 
 package server
 

--- a/cli/server/server.go
+++ b/cli/server/server.go
@@ -1,16 +1,5 @@
 // Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: BSD-3-Clause
 
 package server
 

--- a/cli/server/service/keepalive.go
+++ b/cli/server/service/keepalive.go
@@ -1,16 +1,5 @@
 // Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: BSD-3-Clause
 
 package service
 

--- a/cli/server/service/package_test.go
+++ b/cli/server/service/package_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 package service
 
 import "testing"

--- a/cli/server/service/service.go
+++ b/cli/server/service/service.go
@@ -1,16 +1,5 @@
 // Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: BSD-3-Clause
 
 package service
 

--- a/cli/server/utils/common.go
+++ b/cli/server/utils/common.go
@@ -1,16 +1,5 @@
 // Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: BSD-3-Clause
 
 package utils
 

--- a/cli/server/utils/common_test.go
+++ b/cli/server/utils/common_test.go
@@ -1,16 +1,5 @@
 // Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: BSD-3-Clause
 
 package utils
 

--- a/docs/javascript/updateStars.js
+++ b/docs/javascript/updateStars.js
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 let githubStarsCache = null;
 
 async function fetchGithubStars() {

--- a/repolint.json
+++ b/repolint.json
@@ -162,7 +162,8 @@
               "types\/",
               "uthash.h",
               "sdk\/include\/external\/",
-              "third-party\/"
+              "third-party\/",
+              "cli\/server\/docs\/ui\/swagger-.*\\.js"
             ]
           },
           "lineCount": 200,
@@ -205,7 +206,8 @@
               "types\/",
               "uthash.h",
               "sdk\/include\/external\/",
-              "third-party\/"
+              "third-party\/",
+              "cli\/server\/docs\/ui\/swagger-.*\\.js"
             ]
           },
           "lineCount": 200,

--- a/sdk/benchmark/benchmark.c
+++ b/sdk/benchmark/benchmark.c
@@ -1,8 +1,7 @@
+// Copyright (c) 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 /*
- * Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- *
  * geniex-bench — single-cell C inference benchmark, public-API only.
  *
  * Flag naming follows llama.cpp's `llama-bench` (-r / --repetitions,

--- a/sdk/benchmark/qdc/_qdc.py
+++ b/sdk/benchmark/qdc/_qdc.py
@@ -1,16 +1,5 @@
 # Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Shared QDC primitives: client, job submit/poll, and log download.
 

--- a/sdk/benchmark/qdc/run_qdc_jobs.py
+++ b/sdk/benchmark/qdc/run_qdc_jobs.py
@@ -1,16 +1,5 @@
 # Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Run geniex-bench on a QDC device and render a bench report.
 

--- a/sdk/benchmark/qdc/tests/conftest.py
+++ b/sdk/benchmark/qdc/tests/conftest.py
@@ -1,16 +1,5 @@
 # Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Appium session fixture for the on-device bench run."""
 

--- a/sdk/benchmark/qdc/tests/test_bench.py
+++ b/sdk/benchmark/qdc/tests/test_bench.py
@@ -1,16 +1,5 @@
 # Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """On-device geniex-bench run for QDC Android phones.
 

--- a/sdk/benchmark/qdc/tests/utils.py
+++ b/sdk/benchmark/qdc/tests/utils.py
@@ -1,16 +1,5 @@
 # Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """adb + appium helpers for the on-device bench run (QDC Android phones)."""
 

--- a/sdk/model-manager/crates/core/examples/bench_pull.rs
+++ b/sdk/model-manager/crates/core/examples/bench_pull.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 //! Ad-hoc timing harness: pull one HF repo and print wall-clock +
 //! throughput. Useful when tuning `GENIEX_DL_*` knobs, sanity-checking
 //! proxy setup, or eyeballing throughput after a transport change.

--- a/sdk/model-manager/crates/core/src/config.rs
+++ b/sdk/model-manager/crates/core/src/config.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 use std::path::PathBuf;
 
 /// Persistent configuration for the model Store.

--- a/sdk/model-manager/crates/core/src/error.rs
+++ b/sdk/model-manager/crates/core/src/error.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 use thiserror::Error;
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/sdk/model-manager/crates/core/src/executor/chunk.rs
+++ b/sdk/model-manager/crates/core/src/executor/chunk.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 //! Chunk planner + `.progress` bitmap.
 //!
 //! The chunking policy mirrors the Go CLI: `chunk_size =

--- a/sdk/model-manager/crates/core/src/executor/mod.rs
+++ b/sdk/model-manager/crates/core/src/executor/mod.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 //! Byte-moving executor for [`crate::source::Plan`]s.
 //!
 //! The executor is hub-agnostic: it takes a slice of [`FileSpec`]s and

--- a/sdk/model-manager/crates/core/src/lib.rs
+++ b/sdk/model-manager/crates/core/src/lib.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 pub mod config;
 pub mod error;
 pub mod executor;

--- a/sdk/model-manager/crates/core/src/logging.rs
+++ b/sdk/model-manager/crates/core/src/logging.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 //! Pluggable log sink for the core crate.
 //!
 //! Core has no logging facade and must not depend on the FFI crate —

--- a/sdk/model-manager/crates/core/src/manifest.rs
+++ b/sdk/model-manager/crates/core/src/manifest.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 use serde::{Deserialize, Deserializer, Serialize};
 use std::collections::HashMap;
 

--- a/sdk/model-manager/crates/core/src/manifest_builder.rs
+++ b/sdk/model-manager/crates/core/src/manifest_builder.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 //! Infer a `ModelManifest` from a directory or a list of files.
 //!
 //! Used when the source (LocalFS or a HuggingFace repo) does not ship a

--- a/sdk/model-manager/crates/core/src/mapping.rs
+++ b/sdk/model-manager/crates/core/src/mapping.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 /// Resolve a short model alias to its canonical "org/repo" name.
 ///
 /// Currently single-entry — `qwen3` is kept as the canonical example so

--- a/sdk/model-manager/crates/core/src/paths.rs
+++ b/sdk/model-manager/crates/core/src/paths.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 use crate::error::{Error, Result};
 use crate::manifest::{ModelManifest, ModelType};
 use crate::manifest_builder::QUANT_PRIORITY;

--- a/sdk/model-manager/crates/core/src/pull.rs
+++ b/sdk/model-manager/crates/core/src/pull.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 //! Orchestrate a model download using the [`crate::source::ModelSource`]
 //! + [`crate::executor::Executor`] pair.
 //!

--- a/sdk/model-manager/crates/core/src/query.rs
+++ b/sdk/model-manager/crates/core/src/query.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 //! Resolve a model's remote candidate quantizations without downloading.
 //!
 //! Reuses [`crate::source::ModelSource::plan`] — the same "what does this

--- a/sdk/model-manager/crates/core/src/resume.rs
+++ b/sdk/model-manager/crates/core/src/resume.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 //! Filter `FileSpec`s that still need fetching on a resumed pull.
 //!
 //! The executor does the final chunk-level resume decision from the

--- a/sdk/model-manager/crates/core/src/source/ai_hub/detect.rs
+++ b/sdk/model-manager/crates/core/src/source/ai_hub/detect.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 //! Host chipset auto-detection for AI Hub pulls.
 //!
 //! AI Hub packages qairt assets per (chipset, HTP arch) pair — for

--- a/sdk/model-manager/crates/core/src/source/ai_hub/local_transport.rs
+++ b/sdk/model-manager/crates/core/src/source/ai_hub/local_transport.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 //! [`HttpTransport`] adapter backed by a single local file.
 //!
 //! [`fetch_central_directory`](super::remote_zip::fetch_central_directory)

--- a/sdk/model-manager/crates/core/src/source/ai_hub/manifest.rs
+++ b/sdk/model-manager/crates/core/src/source/ai_hub/manifest.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 //! Minimal serde types for the Qualcomm AI Hub protojson payloads.
 //!
 //! The Go CLI parses these via `protojson.Unmarshal` of the full proto

--- a/sdk/model-manager/crates/core/src/source/ai_hub/mod.rs
+++ b/sdk/model-manager/crates/core/src/source/ai_hub/mod.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 //! Qualcomm AI Hub [`ModelSource`].
 //!
 //! Resolves the asset URL for a `(display_name, chipset)` pair via the

--- a/sdk/model-manager/crates/core/src/source/ai_hub/remote_zip.rs
+++ b/sdk/model-manager/crates/core/src/source/ai_hub/remote_zip.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 //! ZIP64-aware central directory parser driven by HTTP Range reads.
 //!
 //! Given a `Url` to a remote zip, [`fetch_central_directory`] returns

--- a/sdk/model-manager/crates/core/src/source/ai_hub/selector.rs
+++ b/sdk/model-manager/crates/core/src/source/ai_hub/selector.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 //! Pick one asset out of `release-assets.json` for a given chipset.
 //!
 //! Matches the Go CLI's selection logic in

--- a/sdk/model-manager/crates/core/src/source/hf.rs
+++ b/sdk/model-manager/crates/core/src/source/hf.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 //! HuggingFace [`ModelSource`].
 //!
 //! One call to `/api/models/{repo}` gives siblings + sizes. If the

--- a/sdk/model-manager/crates/core/src/source/local_kind.rs
+++ b/sdk/model-manager/crates/core/src/source/local_kind.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 //! Auto-detect the layout of a `local_path` passed to [`LocalFsSource`].
 //!
 //! Three known shapes today:

--- a/sdk/model-manager/crates/core/src/source/localfs.rs
+++ b/sdk/model-manager/crates/core/src/source/localfs.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 //! Local filesystem [`ModelSource`].
 //!
 //! Given a `source_dir` (or a local archive file), reads its layout and

--- a/sdk/model-manager/crates/core/src/source/mod.rs
+++ b/sdk/model-manager/crates/core/src/source/mod.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 //! Plan-then-fetch contract for a single model pull.
 //!
 //! A [`ModelSource`] fully resolves "what does this model consist of" —

--- a/sdk/model-manager/crates/core/src/store.rs
+++ b/sdk/model-manager/crates/core/src/store.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 use std::fs;
 use std::io::Read;
 use std::path::PathBuf;

--- a/sdk/model-manager/crates/core/src/transport.rs
+++ b/sdk/model-manager/crates/core/src/transport.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 //! HTTP transport layer — the minimum a hub needs from the network.
 //!
 //! `HttpTransport` has two methods: HEAD to discover size +

--- a/sdk/model-manager/crates/core/src/validation.rs
+++ b/sdk/model-manager/crates/core/src/validation.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 //! Input validation — protects against path traversal and malformed names.
 
 use crate::error::{Error, Result};

--- a/sdk/model-manager/crates/core/tests/ai_hub_live.rs
+++ b/sdk/model-manager/crates/core/tests/ai_hub_live.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 //! Live tests against the real Qualcomm AI Hub public bucket. Require
 //! network access (and, for the end-to-end pull, ~2 GB of disk +
 //! patience), so they are gated behind `--ignored` and only run when

--- a/sdk/model-manager/crates/core/tests/ai_hub_pull.rs
+++ b/sdk/model-manager/crates/core/tests/ai_hub_pull.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 //! End-to-end AI Hub pull against a wiremock'd server.
 //!
 //! Serves three protojson documents (manifest.json, release-assets.json,

--- a/sdk/model-manager/crates/core/tests/compat.rs
+++ b/sdk/model-manager/crates/core/tests/compat.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 //! Cross-language manifest compatibility: verify that a `geniex.json`
 //! produced by the Go CLI (which uses `sonic.Marshal` with PascalCase
 //! struct field names) round-trips through the Rust model manager

--- a/sdk/model-manager/crates/core/tests/executor.rs
+++ b/sdk/model-manager/crates/core/tests/executor.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 //! Integration tests for the download executor against a wiremock'd
 //! HuggingFace-shaped server. Covers: multi-file + multi-chunk
 //! downloads land byte-correct, the `.progress` bitmap gets each bit

--- a/sdk/model-manager/crates/core/tests/hf_live.rs
+++ b/sdk/model-manager/crates/core/tests/hf_live.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 //! Live test against the HuggingFace Hub. Requires network access, so
 //! it is gated behind `--ignored` and only runs when explicitly
 //! requested:

--- a/sdk/model-manager/crates/core/tests/local_aihub_pull.rs
+++ b/sdk/model-manager/crates/core/tests/local_aihub_pull.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 //! End-to-end pull from a local AI Hub source.
 //!
 //! Two flows are exercised: pulling from an already-extracted directory

--- a/sdk/model-manager/crates/core/tests/proxy_smoke.rs
+++ b/sdk/model-manager/crates/core/tests/proxy_smoke.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 //! Integration tests for [`ReqwestTransport`]: proxy routing, HEAD parsing,
 //! and range GET semantics. Uses `wiremock` to stand up a fake upstream.
 //!

--- a/sdk/model-manager/crates/core/tests/pull_resume.rs
+++ b/sdk/model-manager/crates/core/tests/pull_resume.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 //! End-to-end test for `pull()` resume at chunk granularity.
 //!
 //! Walks a real pull through the HfSource → Executor → ReqwestTransport

--- a/sdk/model-manager/crates/ffi/src/chipset.rs
+++ b/sdk/model-manager/crates/ffi/src/chipset.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 use std::os::raw::c_char;
 
 use model_manager_core::config::StoreConfig;

--- a/sdk/model-manager/crates/ffi/src/init.rs
+++ b/sdk/model-manager/crates/ffi/src/init.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 use std::os::raw::c_char;
 use std::path::PathBuf;
 use std::sync::{Mutex, OnceLock};

--- a/sdk/model-manager/crates/ffi/src/lib.rs
+++ b/sdk/model-manager/crates/ffi/src/lib.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 mod chipset;
 mod init;
 mod logging;

--- a/sdk/model-manager/crates/ffi/src/logging.rs
+++ b/sdk/model-manager/crates/ffi/src/logging.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 //! Bridge to geniex's C log callback.
 //!
 //! On ELF targets we can reach the C++-side global `geniex_log` directly

--- a/sdk/model-manager/crates/ffi/src/mapping.rs
+++ b/sdk/model-manager/crates/ffi/src/mapping.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 use std::os::raw::c_char;
 
 use model_manager_core::mapping::resolve_alias;

--- a/sdk/model-manager/crates/ffi/src/pull.rs
+++ b/sdk/model-manager/crates/ffi/src/pull.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 use std::os::raw::{c_char, c_void};
 use std::path::PathBuf;
 

--- a/sdk/model-manager/crates/ffi/src/query.rs
+++ b/sdk/model-manager/crates/ffi/src/query.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 use std::os::raw::c_char;
 
 use model_manager_core::manifest_builder::ManifestHint;

--- a/sdk/model-manager/crates/ffi/src/store.rs
+++ b/sdk/model-manager/crates/ffi/src/store.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 use std::os::raw::c_char;
 
 use model_manager_core::manifest::ModelType;

--- a/sdk/model-manager/crates/ffi/src/types.rs
+++ b/sdk/model-manager/crates/ffi/src/types.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 use std::cell::RefCell;
 use std::ffi::{CStr, CString};
 use std::os::raw::{c_char, c_void};

--- a/sdk/model-manager/tests/test_model_manager.c
+++ b/sdk/model-manager/tests/test_model_manager.c
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
 /**
  * End-to-end test for the model manager C API.
  *

--- a/tests/_models.py
+++ b/tests/_models.py
@@ -1,16 +1,5 @@
 # Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Test-model identifiers for the SDK pytest matrix.
 

--- a/tests/_quality_data.py
+++ b/tests/_quality_data.py
@@ -1,16 +1,5 @@
 # Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Quality-check prompts and image keywords shared by both plugin matrices.
 

--- a/tests/api/test_compute_unit_list.py
+++ b/tests/api/test_compute_unit_list.py
@@ -1,16 +1,5 @@
 # Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """``geniex.get_compute_unit_list`` shape per runtime."""
 

--- a/tests/api/test_init_deinit.py
+++ b/tests/api/test_init_deinit.py
@@ -1,16 +1,5 @@
 # Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Lifecycle and public-surface checks for the geniex package."""
 

--- a/tests/api/test_resolve_device_map.py
+++ b/tests/api/test_resolve_device_map.py
@@ -1,16 +1,5 @@
 # Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """``geniex.resolve_device_map`` aliases — mirrors ``geniex_resolve_device``.
 

--- a/tests/api/test_runtime_list.py
+++ b/tests/api/test_runtime_list.py
@@ -1,16 +1,5 @@
 # Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """``geniex.get_runtime_list`` shape and contents."""
 

--- a/tests/api/test_version.py
+++ b/tests/api/test_version.py
@@ -1,16 +1,5 @@
 # Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """SDK version metadata."""
 

--- a/tests/cli/cases/__init__.py
+++ b/tests/cli/cases/__init__.py
@@ -1,16 +1,5 @@
 # Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: BSD-3-Clause
 
 from .audio_multi_round import AudioMultiRound
 from .base import BaseCase

--- a/tests/cli/cases/audio_multi_round.py
+++ b/tests/cli/cases/audio_multi_round.py
@@ -1,16 +1,5 @@
 # Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: BSD-3-Clause
 
 from typing import final, override
 

--- a/tests/cli/cases/base.py
+++ b/tests/cli/cases/base.py
@@ -1,16 +1,5 @@
 # Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: BSD-3-Clause
 
 from typing import Any
 

--- a/tests/cli/cases/image_multi_round.py
+++ b/tests/cli/cases/image_multi_round.py
@@ -1,16 +1,5 @@
 # Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: BSD-3-Clause
 
 from typing import final, override
 

--- a/tests/cli/cases/multi_round.py
+++ b/tests/cli/cases/multi_round.py
@@ -1,16 +1,5 @@
 # Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: BSD-3-Clause
 
 from typing import Any, final, override
 

--- a/tests/cli/cases/single_round.py
+++ b/tests/cli/cases/single_round.py
@@ -1,16 +1,5 @@
 # Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: BSD-3-Clause
 
 from typing import final, override
 

--- a/tests/cli/run.py
+++ b/tests/cli/run.py
@@ -1,16 +1,5 @@
 # Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: BSD-3-Clause
 
 #!/usr/bin/env python3
 

--- a/tests/cli/scripts/__init__.py
+++ b/tests/cli/scripts/__init__.py
@@ -1,15 +1,3 @@
 # Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
+# SPDX-License-Identifier: BSD-3-Clause
 

--- a/tests/cli/scripts/config.py
+++ b/tests/cli/scripts/config.py
@@ -1,16 +1,5 @@
 # Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: BSD-3-Clause
 
 import platform
 from typing import TypeAlias

--- a/tests/cli/scripts/log.py
+++ b/tests/cli/scripts/log.py
@@ -1,16 +1,5 @@
 # Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: BSD-3-Clause
 
 import builtins
 import os

--- a/tests/cli/scripts/utils.py
+++ b/tests/cli/scripts/utils.py
@@ -1,16 +1,5 @@
 # Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: BSD-3-Clause
 
 import os
 import platform

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,16 +1,5 @@
 # Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Top-level pytest fixtures for the SDK end-to-end suite.
 

--- a/tests/plugins/llama_cpp/test_llama_cpp_llm.py
+++ b/tests/plugins/llama_cpp/test_llama_cpp_llm.py
@@ -1,16 +1,5 @@
 # Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """llama_cpp LLM matrix: cpu, npu, gpu."""
 

--- a/tests/plugins/llama_cpp/test_llama_cpp_vlm.py
+++ b/tests/plugins/llama_cpp/test_llama_cpp_vlm.py
@@ -1,16 +1,5 @@
 # Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """llama_cpp VLM matrix: cpu, npu, gpu."""
 

--- a/tests/plugins/qairt/test_qairt_llm.py
+++ b/tests/plugins/qairt/test_qairt_llm.py
@@ -1,16 +1,5 @@
 # Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """qairt LLM matrix: npu (only supported backend for qairt)."""
 

--- a/tests/plugins/qairt/test_qairt_vlm.py
+++ b/tests/plugins/qairt/test_qairt_vlm.py
@@ -1,16 +1,5 @@
 # Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """qairt VLM matrix: npu (only supported backend for qairt)."""
 

--- a/tests/qdc/run_qdc_pytest.py
+++ b/tests/qdc/run_qdc_pytest.py
@@ -1,16 +1,5 @@
 # Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Run the SDK model-running pytest suite on a real QDC device.
 


### PR DESCRIPTION
## Summary

Nexa PRs are failing the QC Preflight Checks Repolinter `source-license-headers-exist` rule because 187 source files don't have the required `Copyright` + `SPDX-License-Identifier` / BSD boilerplate in the first 200 lines. This PR fixes all of them.

The repo's `LICENSE` is `BSD-3-Clause`, but 123 of the 187 flagged files still carried Apache-2.0 boilerplate inherited from the pre-migration NexaSDK tree. Another 61 had no header at all. This PR standardizes every touched file on the same 2-line header already used by `sdk/include/utils.h` etc.:

```
// Copyright (c) 2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
// SPDX-License-Identifier: BSD-3-Clause
```

(Files that already had a `Copyright 2024-2026 …` line — i.e. everything with Apache boilerplate — keep the `2024-2026` range; new headers use `2026`.)

## Split into commits by area

Each commit is a single logical area so reviewers can verify one at a time:

1. `chore(repolint)` — exclude third-party `cli/server/docs/ui/swagger-*.js` bundles (unmodified upstream Swagger UI dist; they already ship a `swagger-ui-bundle.js.LICENSE.txt`).
2. `chore(cli)` — 60 Go files under `cli/` (cmd, internal packages, server) + empty `package_test.go` markers.
3. `chore(sdk/benchmark)` — `benchmark.c` + `qdc/` pytest harness (6 files).
4. `chore(sdk/model-manager)` — 45 Rust crate files (core + ffi + tests + example) and one C test binary; none had headers before.
5. `chore(bindings/python)` — 35 files (public `geniex` package, ffi wrappers, tests, setup).
6. `chore(bindings)` — 9 Go binding files + `sync_siblings.py`.
7. `chore(tests)` — 24 files under top-level `tests/` (API tests, CLI cases/scripts, plugin tests, QDC harness).
8. `chore` — 2 misc scripts (`.github/scripts/release.js`, `docs/javascript/updateStars.js`).

## Verification

Ran the exact patterns from `repolint.json` (`source-license-headers-exist`) against every source file after the changes:

```
Total remaining failures: 0
```

## Not in scope

`geniex-proc` and `geniex-qairt-plugin` were checked too — both already pass, no changes needed.

## Test plan

- [x] QC Preflight Checks (`source-license-headers-exist`) passes on CI
- [x] Repolinter output no longer lists these files under the source-license-headers-exist rule
- [x] Build (`go build`, `cargo build`, Python import smoke, C compile) still succeeds — no header comment introduces a syntax issue