### PR TITLE
feat(server): add server-wide nctx/ngl/compute defaults to serve

### DIFF
--- a/cli/cmd/geniex/run.go
+++ b/cli/cmd/geniex/run.go
@@ -118,6 +118,7 @@ func runCompletions(ctx context.Context, name string, modelType geniex_sdk.Model
 		warmUpRequest,
 		option.WithJSONSet("ngl", ngl),
 		option.WithJSONSet("nctx", nctx),
+		option.WithJSONSet("compute", computeUnit),
 	)
 	spin.Stop()
 
@@ -196,6 +197,7 @@ func runCompletions(ctx context.Context, name string, modelType geniex_sdk.Model
 				option.WithJSONSet("grammar_string", grammarString),
 				option.WithJSONSet("ngl", ngl),
 				option.WithJSONSet("nctx", nctx),
+				option.WithJSONSet("compute", computeUnit),
 				option.WithHeaderAdd("GenieX-KeepCache", "true"))
 
 			var firstToken time.Time

--- a/cli/cmd/geniex/serve.go
+++ b/cli/cmd/geniex/serve.go
@@ -27,6 +27,11 @@ func serve() *cobra.Command {
 	serveCmd.Flags().String("host", "127.0.0.1:18181", "Default server address (env: GENIEX_HOST)")
 	serveCmd.Flags().String("origins", "*", "Default CORS origins (env: GENIEX_ORIGINS)")
 	serveCmd.Flags().Int("keepalive", 300, "Keepalive seconds (env: GENIEX_KEEPALIVE)")
+	// Model-load defaults applied when a request omits them (llama_cpp only;
+	// per-request body fields still override).
+	serveCmd.Flags().Int32("nctx", 4096, "Default context window size, llama_cpp only (env: GENIEX_NCTX)")
+	serveCmd.Flags().Int32("ngl", 999, "Default layers to offload to gpu/npu, llama_cpp only (env: GENIEX_NGL)")
+	serveCmd.Flags().String("compute", "", "Default compute unit: cpu, gpu, npu, or hybrid (env: GENIEX_COMPUTE)")
 	// HTTPS / TLS flags
 	serveCmd.Flags().Bool("https", false, "Enable HTTPS/TLS (env: GENIEX_HTTPS)")
 	serveCmd.Flags().String("certfile", "cert.pem", "TLS certificate file path (env: GENIEX_CERTFILE)")
@@ -35,6 +40,9 @@ func serve() *cobra.Command {
 	viper.BindPFlag("host", serveCmd.Flags().Lookup("host"))
 	viper.BindPFlag("origins", serveCmd.Flags().Lookup("origins"))
 	viper.BindPFlag("keepalive", serveCmd.Flags().Lookup("keepalive"))
+	viper.BindPFlag("nctx", serveCmd.Flags().Lookup("nctx"))
+	viper.BindPFlag("ngl", serveCmd.Flags().Lookup("ngl"))
+	viper.BindPFlag("compute", serveCmd.Flags().Lookup("compute"))
 	viper.BindPFlag("enablehttps", serveCmd.Flags().Lookup("https"))
 	viper.BindPFlag("certfile", serveCmd.Flags().Lookup("certfile"))
 	viper.BindPFlag("keyfile", serveCmd.Flags().Lookup("keyfile"))

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -27,6 +27,12 @@ type Config struct {
 	Host      string // Server host and port (default: "127.0.0.1:18181")
 	Origins   string // Allowed CORS origins (default: "*")
 	KeepAlive int64  // Connection keep-alive timeout in seconds (default: 300)
+	// Model-load defaults applied when a request omits them (llama_cpp only;
+	// per-request body fields still override). Compute is the alias resolved by
+	// the SDK (sdk/src/device.cpp); empty means the SDK's own default.
+	NCtx    int32  // Default context window size (default: 4096)
+	Ngl     int32  // Default GPU/NPU layers to offload (default: 999)
+	Compute string // Default compute unit: cpu, gpu, npu, hybrid (default: "")
 	// HTTPS / TLS settings
 	HTTPS    bool   // Whether to serve over HTTPS (default: false)
 	CertFile string // TLS certificate file path

--- a/cli/internal/types/model.go
+++ b/cli/internal/types/model.go
@@ -14,9 +14,11 @@
 
 package types
 
-// ModelParam holds the llama_cpp-only knobs (context size, GPU layers) the
-// keep-alive cache keys model instances on.
+// ModelParam holds the model-load knobs the keep-alive cache keys instances on.
+// NCtx / NGpuLayers are llama_cpp-only; DeviceID is the compute unit resolved by
+// the SDK (empty = the SDK's own default).
 type ModelParam struct {
 	NCtx       int32
 	NGpuLayers int32
+	DeviceID   string
 }

--- a/cli/server/docs/swagger.yaml
+++ b/cli/server/docs/swagger.yaml
@@ -95,8 +95,7 @@ components:
         nctx:
           type: integer
           minimum: 1
-          description: The maximum number of tokens that can be processed in the chat completion
-          default: 4096
+          description: Context window size (llama_cpp only). Omit to use the server default set via `geniex serve --nctx` / `GENIEX_NCTX` (4096 out of the box).
         max_completion_tokens:
           type: integer
           minimum: 1
@@ -176,7 +175,11 @@ components:
           description: Grammar string for structured output
         ngl:
           type: integer
-          description: Number of GPU layers to use. Do not set — the server chooses the correct layout per backend.
+          description: Number of GPU/NPU layers to offload (llama_cpp only). Omit to use the server default set via `geniex serve --ngl` / `GENIEX_NGL` (999 out of the box); the server chooses the correct layout per backend.
+        compute:
+          type: string
+          enum: [cpu, gpu, npu, hybrid]
+          description: Compute unit to run on. Omit to use the server default set via `geniex serve --compute` / `GENIEX_COMPUTE`. QAIRT is NPU-only; other aliases are coerced with a warning.
         image_max_length:
           type: integer
           description: Maximum length for image processing (VLM only)

--- a/cli/server/handler/chat.go
+++ b/cli/server/handler/chat.go
@@ -115,9 +115,9 @@ func ChatCompletions(c *gin.Context) {
 
 	switch modelType {
 	case geniex_sdk.ModelTypeLLM:
-		chatCompletionsLLM(c, param, paths.RuntimeID)
+		chatCompletionsLLM(c, param)
 	case geniex_sdk.ModelTypeVLM:
-		chatCompletionsVLM(c, param, paths.RuntimeID)
+		chatCompletionsVLM(c, param)
 	default:
 		slog.Error("Model type not support", "model_type", modelType)
 		c.JSON(http.StatusBadRequest, map[string]any{"error": "model type not support"})
@@ -125,7 +125,7 @@ func ChatCompletions(c *gin.Context) {
 	}
 }
 
-func chatCompletionsLLM(c *gin.Context, param ChatCompletionRequest, pluginId string) {
+func chatCompletionsLLM(c *gin.Context, param ChatCompletionRequest) {
 	messages := make([]geniex_sdk.LlmChatMessage, 0, len(param.Messages))
 	for _, msg := range param.Messages {
 		if toolCalls := msg.GetToolCalls(); len(toolCalls) > 0 {
@@ -212,7 +212,7 @@ func chatCompletionsLLM(c *gin.Context, param ChatCompletionRequest, pluginId st
 		types.ModelParam{NCtx: param.NCtx, NGpuLayers: param.Ngl},
 		c.GetHeader("GenieX-KeepCache") != "true",
 	)
-	if writeKeepAliveError(c, err, pluginId) {
+	if writeKeepAliveError(c, err) {
 		return
 	}
 	if isWarmupRequest(param) {
@@ -294,7 +294,7 @@ func chatCompletionsLLM(c *gin.Context, param ChatCompletionRequest, pluginId st
 	}
 }
 
-func chatCompletionsVLM(c *gin.Context, param ChatCompletionRequest, pluginId string) {
+func chatCompletionsVLM(c *gin.Context, param ChatCompletionRequest) {
 	messages := make([]geniex_sdk.VlmChatMessage, 0, len(param.Messages))
 	for _, msg := range param.Messages {
 		if toolCalls := msg.GetToolCalls(); len(toolCalls) > 0 {
@@ -433,7 +433,7 @@ func chatCompletionsVLM(c *gin.Context, param ChatCompletionRequest, pluginId st
 		types.ModelParam{NCtx: param.NCtx, NGpuLayers: param.Ngl},
 		c.GetHeader("GenieX-KeepCache") != "true",
 	)
-	if writeKeepAliveError(c, err, pluginId) {
+	if writeKeepAliveError(c, err) {
 		return
 	}
 	if isWarmupRequest(param) {
@@ -560,7 +560,7 @@ func parseTools(param ChatCompletionRequest) (bool, string, error) {
 
 // writeKeepAliveError maps a KeepAliveGet error to its HTTP response;
 // returns true when handled (caller should return).
-func writeKeepAliveError(c *gin.Context, err error, pluginId string) bool {
+func writeKeepAliveError(c *gin.Context, err error) bool {
 	if err == nil {
 		return false
 	}
@@ -569,7 +569,7 @@ func writeKeepAliveError(c *gin.Context, err error, pluginId string) bool {
 		c.JSON(http.StatusNotFound, map[string]any{"error": "model not found"})
 	case errors.Is(err, geniex_sdk.ErrCommonParamNotSupported):
 		c.JSON(http.StatusBadRequest, map[string]any{
-			"error": fmt.Sprintf("a parameter in the request is not supported by the %s runtime", pluginId),
+			"error": "a parameter in the request is not supported by the runtime",
 			"code":  geniex_sdk.SDKErrorCode(err),
 		})
 	default:

--- a/cli/server/handler/chat.go
+++ b/cli/server/handler/chat.go
@@ -36,9 +36,10 @@ type ChatCompletionRequest struct {
 	ChatCompletionNewParams
 	Stream bool `json:"stream"`
 
-	EnableThink bool  `json:"enable_think"`
-	NCtx        int32 `json:"nctx"`
-	Ngl         int32 `json:"ngl"`
+	EnableThink bool   `json:"enable_think"`
+	NCtx        int32  `json:"nctx"`
+	Ngl         int32  `json:"ngl"`
+	Compute     string `json:"compute"`
 
 	ImageMaxLength int32 `json:"image_max_length"`
 
@@ -58,8 +59,9 @@ func defaultChatCompletionRequest() ChatCompletionRequest {
 		Stream: false,
 
 		EnableThink:       true,
-		NCtx:              0, // llama_cpp only; 0 = not set, resolved to 4096 for llama_cpp
-		Ngl:               0, // llama_cpp only; 0 = not set, resolved to 999 for llama_cpp
+		NCtx:              0,  // llama_cpp only; 0 = not set, falls back to server default (--nctx)
+		Ngl:               0,  // llama_cpp only; 0 = not set, falls back to server default (--ngl)
+		Compute:           "", // "" = not set, falls back to server default (--compute)
 		ImageMaxLength:    512,
 		TopK:              0,
 		MinP:              0.0,
@@ -106,18 +108,28 @@ func ChatCompletions(c *gin.Context) {
 		return
 	}
 
+	// Fill unset request knobs from the server-wide defaults and resolve the
+	// compute unit. Done before the MaxCompletionTokens floor so a body that
+	// omits nctx picks up the server default, not the floor.
+	modelParam, err := service.ResolveModelParam(paths.RuntimeID, paths.ModelName, param.NCtx, param.Ngl, param.Compute)
+	if err != nil {
+		slog.Error("Failed to resolve model params", "model", param.Model, "error", err)
+		c.JSON(http.StatusBadRequest, map[string]any{"error": err.Error()})
+		return
+	}
+
 	// Automatically adjust NCtx if MaxCompletionTokens is larger (llama_cpp only — QAIRT
 	// does not use NCtx and the 0-default must not be overwritten for non-llama_cpp plugins).
-	if paths.RuntimeID == geniex_sdk.RuntimeLlamaCpp && param.NCtx < int32(param.MaxCompletionTokens.Value) {
-		slog.Debug("Adjust NCtx to MaxCompletionTokens", "from", param.NCtx, "to", param.MaxCompletionTokens.Value)
-		param.NCtx = int32(param.MaxCompletionTokens.Value)
+	if paths.RuntimeID == geniex_sdk.RuntimeLlamaCpp && modelParam.NCtx < int32(param.MaxCompletionTokens.Value) {
+		slog.Debug("Adjust NCtx to MaxCompletionTokens", "from", modelParam.NCtx, "to", param.MaxCompletionTokens.Value)
+		modelParam.NCtx = int32(param.MaxCompletionTokens.Value)
 	}
 
 	switch modelType {
 	case geniex_sdk.ModelTypeLLM:
-		chatCompletionsLLM(c, param)
+		chatCompletionsLLM(c, param, modelParam)
 	case geniex_sdk.ModelTypeVLM:
-		chatCompletionsVLM(c, param)
+		chatCompletionsVLM(c, param, modelParam)
 	default:
 		slog.Error("Model type not support", "model_type", modelType)
 		c.JSON(http.StatusBadRequest, map[string]any{"error": "model type not support"})
@@ -125,7 +137,7 @@ func ChatCompletions(c *gin.Context) {
 	}
 }
 
-func chatCompletionsLLM(c *gin.Context, param ChatCompletionRequest) {
+func chatCompletionsLLM(c *gin.Context, param ChatCompletionRequest, modelParam types.ModelParam) {
 	messages := make([]geniex_sdk.LlmChatMessage, 0, len(param.Messages))
 	for _, msg := range param.Messages {
 		if toolCalls := msg.GetToolCalls(); len(toolCalls) > 0 {
@@ -209,7 +221,7 @@ func chatCompletionsLLM(c *gin.Context, param ChatCompletionRequest) {
 
 	p, err := service.KeepAliveGet[geniex_sdk.LLM](
 		string(param.Model),
-		types.ModelParam{NCtx: param.NCtx, NGpuLayers: param.Ngl},
+		modelParam,
 		c.GetHeader("GenieX-KeepCache") != "true",
 	)
 	if writeKeepAliveError(c, err) {
@@ -294,7 +306,7 @@ func chatCompletionsLLM(c *gin.Context, param ChatCompletionRequest) {
 	}
 }
 
-func chatCompletionsVLM(c *gin.Context, param ChatCompletionRequest) {
+func chatCompletionsVLM(c *gin.Context, param ChatCompletionRequest, modelParam types.ModelParam) {
 	messages := make([]geniex_sdk.VlmChatMessage, 0, len(param.Messages))
 	for _, msg := range param.Messages {
 		if toolCalls := msg.GetToolCalls(); len(toolCalls) > 0 {
@@ -430,7 +442,7 @@ func chatCompletionsVLM(c *gin.Context, param ChatCompletionRequest) {
 
 	p, err := service.KeepAliveGet[geniex_sdk.VLM](
 		string(param.Model),
-		types.ModelParam{NCtx: param.NCtx, NGpuLayers: param.Ngl},
+		modelParam,
 		c.GetHeader("GenieX-KeepCache") != "true",
 	)
 	if writeKeepAliveError(c, err) {

--- a/cli/server/service/BUILD.bazel
+++ b/cli/server/service/BUILD.bazel
@@ -18,6 +18,10 @@ go_library(
 
 go_cgo_test(
     name = "service_test",
-    srcs = ["package_test.go"],
+    srcs = ["keepalive_test.go"],
     embed = [":service"],
+    deps = [
+        "//bindings/go:geniex_sdk_go",
+        "@com_github_spf13_viper//:viper",
+    ],
 )

--- a/cli/server/service/keepalive.go
+++ b/cli/server/service/keepalive.go
@@ -15,6 +15,54 @@ import (
 	"github.com/qualcomm/GenieX/cli/internal/types"
 )
 
+// ResolveModelParam turns the per-request (nctx, ngl, compute) knobs into the
+// ModelParam the keep-alive cache keys on, filling unset fields from the
+// server-wide defaults (config: --nctx / --ngl / --compute). A request value of
+// 0 / "" means "unset, use the server default". NCtx / NGpuLayers are meaningful
+// only for llama_cpp; for other plugins (e.g. qairt) they stay 0 so the plugin's
+// param-guard is not tripped. Compute is resolved to a concrete DeviceID by the
+// SDK (sdk/src/device.cpp); any coercion warning is logged.
+//
+// Every handler that loads a model must build its ModelParam through this so the
+// server-wide defaults and device resolution apply uniformly.
+func ResolveModelParam(runtimeID, modelName string, reqNCtx, reqNgl int32, reqCompute string) (types.ModelParam, error) {
+	cfg := config.Get()
+
+	nctx, ngl := reqNCtx, reqNgl
+	if runtimeID == geniex_sdk.RuntimeLlamaCpp {
+		if nctx == 0 {
+			nctx = cfg.NCtx
+		}
+		if ngl == 0 {
+			ngl = cfg.Ngl
+		}
+	}
+
+	compute := reqCompute
+	if compute == "" {
+		compute = cfg.Compute
+	}
+
+	resolved, err := geniex_sdk.ResolveDevice(geniex_sdk.ResolveDeviceInput{
+		RuntimeID:   runtimeID,
+		ModelName:   modelName,
+		ComputeUnit: compute,
+		NglDefault:  ngl,
+	})
+	if err != nil {
+		return types.ModelParam{}, err
+	}
+	if resolved.Warning != "" {
+		slog.Warn("compute unit coerced", "warning", resolved.Warning)
+	}
+
+	return types.ModelParam{
+		NCtx:       nctx,
+		NGpuLayers: resolved.Ngl,
+		DeviceID:   resolved.DeviceID,
+	}, nil
+}
+
 // KeepAliveGet retrieves a model from the keepalive cache or creates it if not found
 // This avoids the overhead of repeatedly loading/unloading models from disk
 func KeepAliveGet[T any](name string, param types.ModelParam, reset bool) (*T, error) {
@@ -124,21 +172,9 @@ func keepAliveGet[T any](name string, param types.ModelParam, reset bool) (any, 
 		delete(keepAlive.models, name)
 	}
 
-	// Resolve llama_cpp-only defaults: NCtx and NGpuLayers are meaningful only for
-	// llama_cpp. For other plugins (e.g. qairt) they must stay 0 so the plugin's
-	// param-guard is not tripped by the request defaults.
-	// TODO: Remove this resolution once the C API exposes geniex_get_last_error_detail()
-	// and the plugin can report the exact unsupported param name directly.
-	nctx, ngl := param.NCtx, param.NGpuLayers
-	if paths.RuntimeID == geniex_sdk.RuntimeLlamaCpp {
-		if nctx == 0 {
-			nctx = 4096
-		}
-		if ngl == 0 {
-			ngl = 999
-		}
-	}
-
+	// param already carries the resolved NCtx / NGpuLayers / DeviceID (see
+	// resolveServeModelParam in the chat handler); the cache keys on it, so no
+	// further resolution happens here.
 	var t keepable
 	var e error
 	switch reflect.TypeFor[T]() {
@@ -146,9 +182,10 @@ func keepAliveGet[T any](name string, param types.ModelParam, reset bool) (any, 
 		t, e = geniex_sdk.NewLLM(geniex_sdk.LlmCreateInput{
 			ModelName: paths.ModelName,
 			ModelPath: modelfile,
+			DeviceID:  param.DeviceID,
 			Config: geniex_sdk.ModelConfig{
-				NCtx:       nctx,
-				NGpuLayers: ngl,
+				NCtx:       param.NCtx,
+				NGpuLayers: param.NGpuLayers,
 			},
 			RuntimeID: paths.RuntimeID,
 		})
@@ -157,9 +194,10 @@ func keepAliveGet[T any](name string, param types.ModelParam, reset bool) (any, 
 			ModelName:  paths.ModelName,
 			ModelPath:  modelfile,
 			MmprojPath: paths.MmprojPath,
+			DeviceID:   param.DeviceID,
 			Config: geniex_sdk.ModelConfig{
-				NCtx:       nctx,
-				NGpuLayers: ngl,
+				NCtx:       param.NCtx,
+				NGpuLayers: param.NGpuLayers,
 			},
 			RuntimeID: paths.RuntimeID,
 		})

--- a/cli/server/service/keepalive_test.go
+++ b/cli/server/service/keepalive_test.go
@@ -1,0 +1,92 @@
+// Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
+package service
+
+import (
+	"testing"
+
+	"github.com/spf13/viper"
+
+	geniex_sdk "github.com/qualcomm/GenieX/bindings/go"
+)
+
+// TestResolveModelParam_LlamaCppFallsBackToServerDefault verifies that a request
+// omitting nctx / ngl (0) picks up the server-wide defaults for llama_cpp. The
+// compute alias is "gpu" so ngl is passed through verbatim — hybrid/npu would
+// force ngl=999 in the SDK regardless of the default.
+func TestResolveModelParam_LlamaCppFallsBackToServerDefault(t *testing.T) {
+	viper.Reset()
+	viper.Set("nctx", int32(8192))
+	viper.Set("ngl", int32(42))
+	t.Cleanup(viper.Reset)
+
+	got, err := ResolveModelParam(geniex_sdk.RuntimeLlamaCpp, "some-model", 0, 0, "gpu")
+	if err != nil {
+		t.Fatalf("ResolveModelParam: %v", err)
+	}
+	if got.NCtx != 8192 {
+		t.Errorf("NCtx = %d, want 8192 (server default)", got.NCtx)
+	}
+	if got.NGpuLayers != 42 {
+		t.Errorf("NGpuLayers = %d, want 42 (server default via gpu)", got.NGpuLayers)
+	}
+}
+
+// TestResolveModelParam_RequestOverridesServerDefault verifies that a non-zero
+// request nctx / ngl wins over the server default.
+func TestResolveModelParam_RequestOverridesServerDefault(t *testing.T) {
+	viper.Reset()
+	viper.Set("nctx", int32(8192))
+	viper.Set("ngl", int32(42))
+	t.Cleanup(viper.Reset)
+
+	got, err := ResolveModelParam(geniex_sdk.RuntimeLlamaCpp, "some-model", 2048, 10, "gpu")
+	if err != nil {
+		t.Fatalf("ResolveModelParam: %v", err)
+	}
+	if got.NCtx != 2048 {
+		t.Errorf("NCtx = %d, want 2048 (request override)", got.NCtx)
+	}
+	if got.NGpuLayers != 10 {
+		t.Errorf("NGpuLayers = %d, want 10 (request override)", got.NGpuLayers)
+	}
+}
+
+// TestResolveModelParam_ComputeDefaultResolvesDevice verifies that an omitted
+// compute falls back to the server default and gets resolved to a concrete
+// device id (llama_cpp "npu" pins HTP0 and forces ngl=999).
+func TestResolveModelParam_ComputeDefaultResolvesDevice(t *testing.T) {
+	viper.Reset()
+	viper.Set("compute", "npu")
+	t.Cleanup(viper.Reset)
+
+	got, err := ResolveModelParam(geniex_sdk.RuntimeLlamaCpp, "some-model", 0, 0, "")
+	if err != nil {
+		t.Fatalf("ResolveModelParam: %v", err)
+	}
+	if got.DeviceID != "HTP0" {
+		t.Errorf("DeviceID = %q, want HTP0 (server compute default)", got.DeviceID)
+	}
+	if got.NGpuLayers != 999 {
+		t.Errorf("NGpuLayers = %d, want 999 (npu forces full offload)", got.NGpuLayers)
+	}
+}
+
+// TestResolveModelParam_NonLlamaCppKeepsZeroNCtx verifies that for non-llama_cpp
+// runtimes NCtx stays 0 (server nctx/ngl defaults must not trip the plugin's
+// param-guard).
+func TestResolveModelParam_NonLlamaCppKeepsZeroNCtx(t *testing.T) {
+	viper.Reset()
+	viper.Set("nctx", int32(8192))
+	viper.Set("ngl", int32(42))
+	t.Cleanup(viper.Reset)
+
+	got, err := ResolveModelParam(geniex_sdk.RuntimeQairt, "some-model", 0, 0, "")
+	if err != nil {
+		t.Fatalf("ResolveModelParam: %v", err)
+	}
+	if got.NCtx != 0 {
+		t.Errorf("NCtx = %d, want 0 for non-llama_cpp", got.NCtx)
+	}
+}

--- a/cli/server/service/package_test.go
+++ b/cli/server/service/package_test.go
@@ -1,8 +1,0 @@
-// Copyright (c) 2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-// SPDX-License-Identifier: BSD-3-Clause
-
-package service
-
-import "testing"
-
-func TestPackageBuilds(t *testing.T) {}


### PR DESCRIPTION
## Summary

`geniex serve` hardcoded `nctx=4096` / `ngl=999` and never set a compute device, so the context window and compute unit could only be changed per-request via the JSON body — there was no server-wide default, and `geniex infer --nctx` (a separate process) had no effect on `serve`.

This adds server-wide defaults, applied only when a request omits the field; per-request body fields still override.

| Flag | Env | Default |
|------|-----|---------|
| `--nctx` | `GENIEX_NCTX` | 4096 |
| `--ngl` | `GENIEX_NGL` | 999 |
| `--compute` | `GENIEX_COMPUTE` | (SDK default) |

### Notes

- Request-param resolution is centralized in `service.ResolveModelParam` so any model-loading handler applies the defaults and device resolution uniformly; `keepalive` becomes a pure consumer of the resolved `ModelParam`. `--compute` is resolved to a concrete `DeviceID` via the SDK and keyed into the keepalive cache — this also closes the gap where `serve` could never select a compute unit at all.
- The `max_completion_tokens` floor now runs *after* defaults are resolved, so a body that omits `nctx` picks up the server default instead of the floor.
- A preparatory `refactor(server)` commit drops the unused `pluginId` plumbing from the chat handlers first, so the feature lands on a clean interface.

## Test plan

- [x] `bazelisk build //cli` + `//cli/server/...` and config unit tests pass
- [x] New `ResolveModelParam` tests cover fallback / body-override / device-resolution / non-llama_cpp branches
- [x] E2E on local Qwen3-0.6B-GGUF: `GENIEX_NCTX=8192` + body without `nctx` → model loads at `n_ctx=8192`
- [x] E2E: `GENIEX_COMPUTE=cpu` → all layers assigned to CPU
- [x] E2E: body `"nctx":2048` overrides the server default → model reloads at `n_ctx=2048`

Closes #1138