### PR TITLE
docs(python): update install instructions to use production PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ geniex infer ai-hub-models/Qwen2.5-VL-7B-Instruct
 **Install**
 
 ```bash
-pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple geniex
+pip install geniex
 ```
 
 **Run** — mirrors Hugging Face `transformers` (`from_pretrained()` → `.generate()`):

--- a/bindings/python/BUILD.md
+++ b/bindings/python/BUILD.md
@@ -40,15 +40,20 @@ is skipped entirely. See GH #538.
 ## Install sources
 
 ```bash
-# From GitHub Release (canonical) — pick the distribution you need
-pip install https://github.com/qualcomm/GenieX/releases/download/v0.0.3-alpha.1/geniex-0.0.3a1.tar.gz
-pip install https://github.com/qualcomm/GenieX/releases/download/v0.0.3-alpha.1/geniex_llama_cpp-0.0.3a1.tar.gz
-pip install https://github.com/qualcomm/GenieX/releases/download/v0.0.3-alpha.1/geniex_qairt-0.0.3a1.tar.gz
+# From PyPI (stable releases)
+pip install geniex
+pip install geniex-llama-cpp
+pip install geniex-qairt
 
 # From TestPyPI (pre-release tags are auto-published)
 pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple geniex
 pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple geniex-llama-cpp
 pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple geniex-qairt
+
+# From GitHub Release (canonical) — pick the distribution you need
+pip install https://github.com/qualcomm/GenieX/releases/download/v0.0.3-alpha.1/geniex-0.0.3a1.tar.gz
+pip install https://github.com/qualcomm/GenieX/releases/download/v0.0.3-alpha.1/geniex_llama_cpp-0.0.3a1.tar.gz
+pip install https://github.com/qualcomm/GenieX/releases/download/v0.0.3-alpha.1/geniex_qairt-0.0.3a1.tar.gz
 ```
 
 ### Supported platforms (automatic SDK download)

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -16,9 +16,9 @@ plugin libraries the install-time SDK fetcher stages:
 | `pip install geniex-qairt`     | QAIRT only               | ~210 MB         |
 
 ```bash
-pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple geniex
+pip install geniex
 # or, e.g.:
-# pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple geniex-llama-cpp
+# pip install geniex-llama-cpp
 ```
 
 The three distributions share the same top-level ``geniex`` package — they

--- a/docs/cn/run/python/install.mdx
+++ b/docs/cn/run/python/install.mdx
@@ -24,15 +24,15 @@ GenieX Python SDK 以 ARM64 wheel 形式发布，覆盖 Windows ARM64 与 Linux 
     python -c "import platform; print(platform.machine())"
     ```
 
-    创建虚拟环境并从 test PyPI 安装：
+    创建虚拟环境并安装：
 
     ```powershell
     python -m venv geniex-env
     .\geniex-env\Scripts\Activate.ps1
-    pip install -U -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple geniex
+    pip install -U geniex
     ```
 
-    这将从 [test PyPI](https://test.pypi.org/project/geniex/) 拉取 Python 包。
+    这将从 [PyPI](https://pypi.org/project/geniex/) 拉取 Python 包。
   </Tab>
 
   <Tab title="Linux ARM64">
@@ -45,10 +45,10 @@ GenieX Python SDK 以 ARM64 wheel 形式发布，覆盖 Windows ARM64 与 Linux 
     直接 pip install：
 
     ```bash
-    python3 -m pip install -U -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple geniex
+    python3 -m pip install -U geniex
     ```
 
-    这将从 [test PyPI](https://test.pypi.org/project/geniex/) 拉取 Python 包，并自动获取 Linux ARM64 SDK 库。
+    这将从 [PyPI](https://pypi.org/project/geniex/) 拉取 Python 包，并自动获取 Linux ARM64 SDK 库。
 
     <Note>
     如设备未预装 Python，请参考常见问题中的[如何在 Linux ARM64 设备上安装 Python？](/cn/resources/faq#如何在-linux-arm64-设备上安装-python)（已验证可用的 Miniconda 流程，覆盖 Qualcomm Yocto 与 Ubuntu ARM64）。

--- a/docs/en/run/python/install.mdx
+++ b/docs/en/run/python/install.mdx
@@ -24,15 +24,15 @@ The GenieX Python SDK ships as an ARM64 wheel for Windows ARM64 and Linux ARM64.
     python -c "import platform; print(platform.machine())"
     ```
 
-    Create a virtual environment and install from test PyPI:
+    Create a virtual environment and install:
 
     ```powershell
     python -m venv geniex-env
     .\geniex-env\Scripts\Activate.ps1
-    pip install -U -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple geniex
+    pip install -U geniex
     ```
 
-    This pulls the package from [test PyPI](https://test.pypi.org/project/geniex/).
+    This pulls the package from [PyPI](https://pypi.org/project/geniex/).
   </Tab>
 
   <Tab title="Linux ARM64">
@@ -45,10 +45,10 @@ The GenieX Python SDK ships as an ARM64 wheel for Windows ARM64 and Linux ARM64.
     Directly pip install:
 
     ```bash
-    python3 -m pip install -U -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple geniex
+    python3 -m pip install -U geniex
     ```
 
-    This pulls the package from [test PyPI](https://test.pypi.org/project/geniex/) and auto-fetches the Linux ARM64 SDK libraries.
+    This pulls the package from [PyPI](https://pypi.org/project/geniex/) and auto-fetches the Linux ARM64 SDK libraries.
 
     <Note>
     If Python is not pre-installed, see [How do I install Python on a Linux ARM64 device?](/en/resources/faq#how-do-i-install-python-on-a-linux-arm64-device) for a verified Miniconda recipe (covers Qualcomm Yocto and Ubuntu ARM64).


### PR DESCRIPTION
## Summary

- Replace all user-facing TestPyPI install commands (`-i https://test.pypi.org/simple/ --extra-index-url ...`) with plain `pip install geniex` now that the package is published on production PyPI.
- Update surrounding prose in `docs/en` and `docs/cn` install pages to reference PyPI instead of test PyPI.
- `bindings/python/BUILD.md` gains a new "From PyPI" block as the primary install source; the TestPyPI block remains (pre-releases still go there).

Closes #1150

## Test plan

- [x] Confirm `pip install geniex` resolves correctly from https://pypi.org/project/geniex/ (package is already live at 0.3.14)