### PR TITLE
fix(sdk): load non-ASCII image paths in qairt VLM on Windows

### DIFF
--- a/sdk/plugins/qairt/include/path_utils.h
+++ b/sdk/plugins/qairt/include/path_utils.h
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include <string>
+
+#if defined(_WIN32)
+#include <windows.h>
+#endif
+
+namespace geniex::qairt {
+
+// The vision pipeline (geniex-proc) opens image files with std::filesystem and stb_image,
+// both of which interpret narrow paths in the active ANSI code page rather than UTF-8. On
+// Windows that breaks any non-ASCII path. Collapse the UTF-8 path to its 8.3 short name and
+// re-encode it in that same ANSI code page, so those APIs open it correctly. No-op elsewhere,
+// and falls back to the original path when no ANSI-representable short name is available (e.g.
+// 8.3 disabled on the volume).
+inline std::string to_loadable_path(const std::string& utf8_path) {
+#if defined(_WIN32)
+    int wlen = MultiByteToWideChar(CP_UTF8, 0, utf8_path.c_str(), -1, nullptr, 0);
+    if (wlen <= 0) return utf8_path;
+    std::wstring wpath(wlen, L'\0');
+    MultiByteToWideChar(CP_UTF8, 0, utf8_path.c_str(), -1, wpath.data(), wlen);
+
+    DWORD slen = GetShortPathNameW(wpath.c_str(), nullptr, 0);
+    if (slen == 0) return utf8_path;
+    std::wstring wshort(slen, L'\0');
+    if (GetShortPathNameW(wpath.c_str(), wshort.data(), slen) == 0) return utf8_path;
+
+    // Encode in the active ANSI code page — the exact encoding the downstream narrow-path APIs
+    // decode with. If any character has no ANSI representation, bail to the original path rather
+    // than hand over a lossy substitution.
+    int nlen = WideCharToMultiByte(CP_ACP, 0, wshort.c_str(), -1, nullptr, 0, nullptr, nullptr);
+    if (nlen <= 0) return utf8_path;
+    std::string narrow(nlen, '\0');
+    BOOL        used_default = FALSE;
+    WideCharToMultiByte(CP_ACP, 0, wshort.c_str(), -1, narrow.data(), nlen, nullptr, &used_default);
+    if (used_default) return utf8_path;
+    narrow.resize(nlen - 1);  // drop the terminating NUL from the count
+    return narrow;
+#else
+    return utf8_path;
+#endif
+}
+
+}  // namespace geniex::qairt

--- a/sdk/plugins/qairt/src/llm.cpp
+++ b/sdk/plugins/qairt/src/llm.cpp
@@ -262,22 +262,21 @@ int32_t QairtLlm::generate(const geniex_LlmGenerateInput* input, geniex_LlmGener
     output->profile_data.prefill_speed =
         result.prompt_tokens > 0 && result.ttft_ms > 0.0 ? result.prompt_tokens / (result.ttft_ms / 1000.0) : 0.0;
 
-    // Stop reason (string must be static/persistent).
-    static const char* kStopEos    = "eos";
-    static const char* kStopLength = "length";
-    static const char* kStopUser   = "user";
-    if (result.stop_reason == "eos")
-        output->profile_data.stop_reason = kStopEos;
-    else if (result.stop_reason == "length" || result.stop_reason == "context_length")
-        output->profile_data.stop_reason = kStopLength;
-    else if (result.stop_reason == "user")
-        output->profile_data.stop_reason = kStopUser;
-    else
-        output->profile_data.stop_reason = kStopEos;
-
-    if (result.stop_reason == "context_length") {
+    // Stop Reason
+    if (result.stop_reason == "user") {
+        output->profile_data.stop_reason = "user";
+    } else if (result.stop_reason == "length") {
+        output->profile_data.stop_reason = "length";
+    } else if (result.stop_reason == "context_length") {
+        output->profile_data.stop_reason = "length";
         GENIEX_LOG_WARN("QAIRT generate: context length exceeded (partial result populated)");
         return GENIEX_ERROR_LLM_TOKENIZATION_CONTEXT_LENGTH;
+    } else if (result.stop_reason == "error") {
+        output->profile_data.stop_reason = "eos";
+        GENIEX_LOG_ERROR("QAIRT generate failed during prompt processing (empty result)");
+        return GENIEX_ERROR_LLM_GENERATION_FAILED;
+    } else {
+        output->profile_data.stop_reason = "eos";
     }
     return GENIEX_SUCCESS;
 }

--- a/sdk/plugins/qairt/src/vlm.cpp
+++ b/sdk/plugins/qairt/src/vlm.cpp
@@ -19,6 +19,7 @@
 #include "geniex-proc/types.h"    // ChatMessage, MMContent, Role::, Modality::
 #include "llm/llm_spec_loader.h"  // parseGenieSamplerConfig
 #include "logging.h"
+#include "path_utils.h"
 #include "pipeline/vlm_pipeline.h"
 #include "qnn_runtime_utils.h"
 #include "sampler_config_utils.h"
@@ -247,7 +248,7 @@ int32_t QairtVlm::generate(const geniex_VlmGenerateInput* input, geniex_VlmGener
         image_paths.reserve(static_cast<size_t>(input->config->image_count));
         for (int32_t i = 0; i < input->config->image_count; ++i) {
             if (input->config->image_paths[i]) {
-                image_paths.emplace_back(input->config->image_paths[i]);
+                image_paths.emplace_back(qairt::to_loadable_path(input->config->image_paths[i]));
             }
         }
     }
@@ -289,22 +290,21 @@ int32_t QairtVlm::generate(const geniex_VlmGenerateInput* input, geniex_VlmGener
                                                 ? static_cast<double>(result.prompt_tokens) / (result.ttft_ms / 1000.0)
                                                 : 0.0;
 
-    // Stop reason.
-    static const char* kStopEos    = "eos";
-    static const char* kStopLength = "length";
-    static const char* kStopUser   = "user";
-    if (result.stop_reason == "eos")
-        output->profile_data.stop_reason = kStopEos;
-    else if (result.stop_reason == "length" || result.stop_reason == "context_length")
-        output->profile_data.stop_reason = kStopLength;
-    else if (result.stop_reason == "user")
-        output->profile_data.stop_reason = kStopUser;
-    else
-        output->profile_data.stop_reason = kStopEos;
-
-    if (result.stop_reason == "context_length") {
+    // Stop Reason
+    if (result.stop_reason == "user") {
+        output->profile_data.stop_reason = "user";
+    } else if (result.stop_reason == "length") {
+        output->profile_data.stop_reason = "length";
+    } else if (result.stop_reason == "context_length") {
+        output->profile_data.stop_reason = "length";
         GENIEX_LOG_WARN("QAIRT VLM generate: context length exceeded (partial result populated)");
         return GENIEX_ERROR_LLM_TOKENIZATION_CONTEXT_LENGTH;
+    } else if (result.stop_reason == "error") {
+        output->profile_data.stop_reason = "eos";
+        GENIEX_LOG_ERROR("QAIRT VLM generate failed during prompt processing (empty result)");
+        return GENIEX_ERROR_VLM_GENERATION_FAILED;
+    } else {
+        output->profile_data.stop_reason = "eos";
     }
     return GENIEX_SUCCESS;
 }


### PR DESCRIPTION
## Summary

On Chinese/non-ASCII Windows, `geniex infer` with a qairt VLM model failed to
process any image whose path contained non-ASCII characters — generation
returned an empty result with `prompt_tokens: 0` and no error.

Two distinct problems, both fixed in the qairt plugin layer:

1. **Non-ASCII path loading.** The vision pipeline (`geniex-proc`) opens image
   files with `std::filesystem` and `stb_image`, both of which interpret narrow
   paths in the active ANSI code page (GBK on Chinese Windows) rather than UTF-8.
   New header-only helper `geniex::qairt::to_loadable_path` collapses the UTF-8
   path to its ASCII 8.3 short name before handing it to the pipeline. No-op on
   non-Windows, and falls back to the original path when a short name is
   unavailable (e.g. 8.3 disabled on the volume).

2. **Silent failure.** When image/prompt processing throws, the pipeline catches
   it and returns `stop_reason == "error"`, which the plugin previously treated
   as a normal EOS stop (`GENIEX_SUCCESS` + empty output). Both the VLM and LLM
   plugins now recognize `"error"` and return a generic generation-failed code
   (`GENIEX_ERROR_VLM_GENERATION_FAILED` / `GENIEX_ERROR_LLM_GENERATION_FAILED`),
   so the CLI reports the error and exits non-zero.

The fix stays entirely in the qairt plugin — no third-party submodule or public
SDK header changes.

## Test plan

Verified on `qcs` (Windows arm64) with `qualcomm/Qwen2.5-VL-7B-Instruct`:

- [x] Chinese image path — before: `prompt_tokens: 0`, empty output; after: `prompt_tokens: 243`, correct image description, exit 0.
- [x] Corrupt image (fails `stbi_load`) — before: empty output, exit 0; after: `SDKError(Multimodal generation failed)`, exit 1.
- [x] ASCII valid path — no regression, generates normally.
- [x] `clang-format` clean on all touched files.

Closes #1147