### PR TITLE
ci(release): use Trusted Publishing for production PyPI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -446,6 +446,9 @@ jobs:
     if: needs.resolve-tag.outputs.is_prerelease != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      # OIDC token for PyPI Trusted Publishing — no API token needed.
+      id-token: write
     steps:
       - uses: actions/download-artifact@v8
         with:
@@ -455,11 +458,8 @@ jobs:
       - name: Publish sdist to PyPI
         uses: pypa/gh-action-pypi-publish@v1.14.0
         with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
           packages-dir: dist/
           skip-existing: true
-          # API-token auth, not Trusted Publishing — attestations are a no-op.
-          attestations: false
 
   # Uploads the AAR to the Sonatype Central Portal under com.qualcomm.qti:geniex-android.
   # Stable tags only. Default publishingType is USER_MANAGED — upload lands in the Portal


### PR DESCRIPTION
## Summary

A PyPI trusted publisher has been configured for this repo (production PyPI only). This switches the `publish-pypi` job from API-token auth to OIDC-based Trusted Publishing:

- Removed `password: ${{ secrets.PYPI_API_TOKEN }}`.
- Added `permissions: id-token: write` so GitHub mints the OIDC token PyPI expects.
- Dropped `attestations: false` — under Trusted Publishing the action generates and uploads PEP 740 attestations automatically.

`publish-testpypi` is left on `TEST_PYPI_API_TOKEN`, since the trusted publisher was only set up for production PyPI.

### Trusted publisher config must match
The publish will fail unless the PyPI trusted-publisher entry matches this workflow exactly:
- Workflow filename: `release.yml`
- Environment name: **blank** — this job has no `environment:` set.

## Test plan

- [ ] Cut a stable `vX.Y.Z` tag and confirm `publish-pypi` uploads via OIDC (no token) and attestations appear on PyPI.