### PR TITLE
feat(sdk): support input_ids and get_model_info in qairt plugin

### DIFF
--- a/sdk/benchmark/benchmark.c
+++ b/sdk/benchmark/benchmark.c
@@ -208,9 +208,9 @@ static void usage(const char* argv0) {
         "                         positions with `rand() %% vocab_size` (BOS at pos 0\n"
         "                         when the model wants one) and feeds them via\n"
         "                         input_ids, so `pp` is exactly N for every model.\n"
-        "                         The qairt plugin currently rejects input_ids; the\n"
-        "                         tool fails with a clear error pointing to the\n"
-        "                         tracking issue.\n"
+        "                         Requires the plugin to implement\n"
+        "                         geniex_llm_get_model_info; the tool fails with a\n"
+        "                         clear error otherwise.\n"
         "  -n, --n-gen N          tokens to generate per run; default 128\n"
         "  -c, --ctx-size N       model n_ctx (0 = from model, default 0)\n"
         "  -t, --threads N        generation threads (0 = SDK default)\n"
@@ -222,8 +222,8 @@ static void usage(const char* argv0) {
         "  --seed N               default 42; also seeds rand() for prompt ids\n"
         "  --prompt-file PATH     opt out of random-ids prefill: read a UTF-8 prompt\n"
         "                         from PATH and feed it via prompt_utf8 instead. The\n"
-        "                         only way to bench plugins that don't support\n"
-        "                         input_ids (today: qairt). With this flag, reported\n"
+        "                         only way to bench plugins that don't implement\n"
+        "                         geniex_llm_get_model_info. With this flag, reported\n"
         "                         `pp` is the tokenizer's count, NOT --n-prompt.\n"
         "                         For qairt, `pp` and prefill tok/s are reported over\n"
         "                         the padded length ceil(pp/128)*128, matching the\n"
@@ -561,7 +561,7 @@ static char* resolve_local_anchor(const char* path) {
 }
 
 /* Load whole file into a heap buffer (caller frees). Used by --prompt-file
- * for plugins that don't support input_ids (qairt). */
+ * for plugins that don't implement geniex_llm_get_model_info. */
 static char* slurp(const char* path) {
     FILE* f = fopen(path, "rb");
     if (!f) {
@@ -989,7 +989,7 @@ static void run_llm(const options_t* o, const char* device_id, int32_t ngl, run_
     /* Two prefill modes, picked by whether --prompt-file was passed:
      *   - prompt_buf != NULL: feed prompt_utf8 verbatim (the plugin tokenizes).
      *     `pp` is the tokenizer's count, NOT n_prompt. Required for plugins
-     *     that don't accept input_ids (today: qairt).
+     *     that don't implement geniex_llm_get_model_info.
      *   - prompt_buf == NULL: random-ids mode (mirrors llama-bench
      *     test_prompt) — query vocab + BOS via geniex_llm_get_model_info,
      *     fill n_prompt positions with rand() % vocab_size, overwrite pos 0

--- a/sdk/include/geniex.h
+++ b/sdk/include/geniex.h
@@ -598,9 +598,9 @@ typedef struct {
  *   - GENIEX_SUCCESS                          on success.
  *   - GENIEX_ERROR_COMMON_NOT_INITIALIZED     when handle is NULL.
  *   - GENIEX_ERROR_COMMON_INVALID_INPUT       when output is NULL.
- *   - GENIEX_ERROR_COMMON_PARAM_NOT_SUPPORTED when the plugin cannot report the metadata
- *                                             (today: qairt). Callers that need vocab_size
- *                                             must treat this as a hard failure.
+ *   - GENIEX_ERROR_COMMON_PARAM_NOT_SUPPORTED when the plugin cannot report the metadata.
+ *                                             Callers that need vocab_size must treat this
+ *                                             as a hard failure.
  */
 GENIEX_API int32_t geniex_llm_get_model_info(geniex_LLM* handle, geniex_LlmModelInfo* output);
 

--- a/sdk/plugins/qairt/include/llm.h
+++ b/sdk/plugins/qairt/include/llm.h
@@ -34,6 +34,8 @@ class QairtLlm : public ILlm {
         const geniex_LlmApplyChatTemplateInput*, geniex_LlmApplyChatTemplateOutput*) override;
 
     virtual int32_t generate(const geniex_LlmGenerateInput*, geniex_LlmGenerateOutput*) override;
+
+    virtual int32_t get_model_info(geniex_LlmModelInfo*) override;
 };
 
 }  // namespace geniex

--- a/sdk/plugins/qairt/src/llm.cpp
+++ b/sdk/plugins/qairt/src/llm.cpp
@@ -217,17 +217,15 @@ int32_t QairtLlm::generate(const geniex_LlmGenerateInput* input, geniex_LlmGener
     if (!pipeline_) return GENIEX_ERROR_COMMON_NOT_INITIALIZED;
     if (!input || !output) return GENIEX_ERROR_COMMON_INVALID_INPUT;
 
+    bool has_input_ids = input->input_ids != nullptr && input->input_ids_count > 0;
+
     // Reject llama.cpp-only parameters that have no meaning in the QAIRT plugin
-    if (input->input_ids && input->input_ids_count > 0) {
-        GENIEX_LOG_ERROR("--token-file (input_ids) is not supported by the qairt plugin");
-        return GENIEX_ERROR_COMMON_PARAM_NOT_SUPPORTED;
-    }
     if (input->config && input->config->stop && input->config->stop_count > 0) {
         GENIEX_LOG_ERROR("--stop / --stop-file (stop sequences) is not supported by the qairt plugin");
         return GENIEX_ERROR_COMMON_PARAM_NOT_SUPPORTED;
     }
 
-    if (!input->prompt_utf8) return GENIEX_ERROR_COMMON_INVALID_INPUT;
+    if (!has_input_ids && !input->prompt_utf8) return GENIEX_ERROR_COMMON_INVALID_INPUT;
 
     // Map geniex_GenerationConfig -> geniex::GenerationConfig
     GenerationConfig gen_cfg{};
@@ -245,8 +243,14 @@ int32_t QairtLlm::generate(const geniex_LlmGenerateInput* input, geniex_LlmGener
         on_token_fn = [cb, ud](const char* token) -> bool { return cb(token, ud); };
     }
 
-    GenerateResult result = pipeline_->generate(input->prompt_utf8, gen_cfg, on_token_fn);
-    is_first_turn_        = false;
+    GenerateResult result;
+    if (has_input_ids) {
+        std::vector<int32_t> input_ids(input->input_ids, input->input_ids + input->input_ids_count);
+        result = pipeline_->generate(input_ids, gen_cfg, on_token_fn);
+    } else {
+        result = pipeline_->generate(input->prompt_utf8, gen_cfg, on_token_fn);
+    }
+    is_first_turn_ = false;
 
     // Map result to output
     output->full_text = portable_strdup(result.full_text.c_str());
@@ -278,6 +282,19 @@ int32_t QairtLlm::generate(const geniex_LlmGenerateInput* input, geniex_LlmGener
     } else {
         output->profile_data.stop_reason = "eos";
     }
+    return GENIEX_SUCCESS;
+}
+
+int32_t QairtLlm::get_model_info(geniex_LlmModelInfo* output) {
+    if (!pipeline_) return GENIEX_ERROR_COMMON_NOT_INITIALIZED;
+    if (!output) return GENIEX_ERROR_COMMON_INVALID_INPUT;
+
+    const size_t vocab_size = pipeline_->vocabSize();
+    if (vocab_size == 0) return GENIEX_ERROR_COMMON_PARAM_NOT_SUPPORTED;
+
+    output->vocab_size = static_cast<int32_t>(vocab_size);
+    output->bos_token  = pipeline_->bosTokenId();
+    output->add_bos    = output->bos_token >= 0 ? 1 : 0;
     return GENIEX_SUCCESS;
 }
 


### PR DESCRIPTION
## Summary

Implements qcom-ai-hub/geniex#1008: plumbs pre-tokenized `input_ids` end-to-end through the QAIRT plugin so `geniex-bench`'s random-ids prefill mode (#1007) works against qairt bundles instead of erroring out.

- `sdk/plugins/qairt/src/llm.cpp`: `QairtLlm::generate()` no longer rejects `input_ids` with `GENIEX_ERROR_COMMON_PARAM_NOT_SUPPORTED`; it now forwards to the new `LLMPipeline::generate(vector<int32_t>, ...)` overload (added in qualcomm/geniex-qairt-plugin#11) when `input_ids`/`input_ids_count` are set, falling back to the existing `prompt_utf8` path otherwise.
- `sdk/plugins/qairt/include/llm.h` / `src/llm.cpp`: implements `QairtLlm::get_model_info()`, surfacing `vocab_size` / `bos_token` / `add_bos` from the loaded bundle via the pipeline's new `vocabSize()`/`bosTokenId()` accessors.
- `sdk/benchmark/benchmark.c`, `sdk/include/geniex.h`: updates stale comments/help text that referenced the old qairt-rejects-`input_ids` behavior (doc-only, no FFI signature changes).

No public SDK header struct/signature changes, so no binding FFI updates are needed per CONTRIBUTING.md § 4.

**Depends on qualcomm/geniex-qairt-plugin#11** (submodule pointer bumped to the CI-green commit).

## Test plan

- [x] Full SDK build (`arm64-windows-snapdragon-release` preset): 809/809 targets built, 0 errors.
- [x] geniex-qairt CPU-only unit tests (no NPU): all pass, including the new `LLMModel.VocabSize` case.
- [x] **On-device NPU run** on a Snapdragon ARM64 Windows machine against the real `qualcomm/Qwen3-4B-Instruct-2507` QAIRT bundle:

  ```
  geniex-bench --plugin qairt --device npu -m <Qwen3-4B-Instruct-2507 bundle> -p 512
  ```

  Random-ids prefill now succeeds end-to-end (`geniex_llm_get_model_info` returns real vocab/BOS data instead of `PARAM_NOT_SUPPORTED`, and `input_ids_count: 512` is fed straight through to the model). Result across 5 measured runs + 1 warmup:

  ```
  [ok] cell  plugin=qairt device=npu(id=NPU) ngl=0 ttft=444.2ms prefill=1152.6tps decode=17.2tps gen=128 tok
  ```

  (prefill ~1.1-1.2k tok/s, decode ~17 tok/s, consistent across repetitions)

- [x] Full GenieX CI suite green: build-sdk (windows/linux/android-arm64), build-cli, test-go, test-python, test-sdk-ci, lint, DCO, QC Preflight Checks.

Closes qcom-ai-hub/geniex#1008
