### PR TITLE
chore(ci): drop dead .apk content-type branch in release.js

### DIFF
--- a/.github/scripts/release.js
+++ b/.github/scripts/release.js
@@ -144,9 +144,7 @@ module.exports = async ({ github, context, core }) => {
               ? "application/gzip"
               : fileName.endsWith(".aar")
                 ? "application/java-archive"
-                : fileName.endsWith(".apk")
-                  ? "application/vnd.android.package-archive"
-                  : "application/zip";
+                : "application/zip";
       await withRetry(
         () =>
           github.rest.repos.uploadReleaseAsset({


### PR DESCRIPTION
This repo's release workflow ships only the AAR, never a demo APK, so the `.apk` MIME-type branch in the release-asset upload script was unreachable. Remove it.