### PR TITLE
feat(qairt): opt-in sliding window CLI flag and env var

### DIFF
--- a/bindings/android/app/src/main/cpp/jniutils.cpp
+++ b/bindings/android/app/src/main/cpp/jniutils.cpp
@@ -152,6 +152,13 @@ geniex_GenerationConfig extract_generation_config(JNIEnv* env, jobject configObj
     cfg.audio_paths = audioPathPtrs.empty() ? nullptr : (geniex_Path*)audioPathPtrs.data();
     cfg.audio_count = audioPathPtrs.size();
 
+    // ----------- sliding window (qcom-ai-hub/geniex#1197) -----------
+    jfieldID slidingWindowId = env->GetFieldID(cls, "slidingWindow", "Z");
+    cfg.sliding_window       = slidingWindowId ? env->GetBooleanField(configObj, slidingWindowId) : false;
+
+    jfieldID slidingWindowNKeepId = env->GetFieldID(cls, "slidingWindowNKeep", "I");
+    cfg.sliding_window_n_keep     = slidingWindowNKeepId ? env->GetIntField(configObj, slidingWindowNKeepId) : 0;
+
     return cfg;
 }
 

--- a/bindings/android/app/src/main/java/com/geniex/sdk/bean/GenerationConfig.kt
+++ b/bindings/android/app/src/main/java/com/geniex/sdk/bean/GenerationConfig.kt
@@ -10,5 +10,9 @@ data class GenerationConfig(
     var imagePaths: Array<String>? = null,
     var imageCount: Int = 0,
     var audioPaths: Array<String>? = null,
-    var audioCount: Int = 0
+    var audioCount: Int = 0,
+
+    // Opt-in ring-buffer context eviction (qairt only).
+    var slidingWindow: Boolean = false,
+    var slidingWindowNKeep: Int = 0 // 0 = plugin default (4)
 )

--- a/bindings/go/common.go
+++ b/bindings/go/common.go
@@ -104,15 +104,21 @@ type GenerationConfig struct {
 	ImagePaths     []string
 	ImageMaxLength int32
 	AudioPaths     []string
+
+	// Opt-in ring-buffer context eviction (qairt only).
+	SlidingWindow      bool
+	SlidingWindowNKeep int32 // 0 = plugin default (4)
 }
 
 // LCOV_EXCL_START
 func (gc GenerationConfig) toCPtr() *C.geniex_GenerationConfig {
 	cPtr := (*C.geniex_GenerationConfig)(cMalloc(C.sizeof_geniex_GenerationConfig))
 	*cPtr = C.geniex_GenerationConfig{
-		max_tokens:       C.int32_t(gc.MaxTokens),
-		n_past:           C.int32_t(gc.NPast),
-		image_max_length: C.int32_t(gc.ImageMaxLength),
+		max_tokens:            C.int32_t(gc.MaxTokens),
+		n_past:                C.int32_t(gc.NPast),
+		image_max_length:      C.int32_t(gc.ImageMaxLength),
+		sliding_window:        C.bool(gc.SlidingWindow),
+		sliding_window_n_keep: C.int32_t(gc.SlidingWindowNKeep),
 	}
 
 	if len(gc.Stop) > 0 {

--- a/bindings/python/geniex/_ffi/_types.py
+++ b/bindings/python/geniex/_ffi/_types.py
@@ -82,6 +82,8 @@ class geniex_GenerationConfig(Structure):
         ('image_max_length', c_int32),
         ('audio_paths', POINTER(c_char_p)),
         ('audio_count', c_int32),
+        ('sliding_window', c_bool),
+        ('sliding_window_n_keep', c_int32),
     ]
 
 

--- a/bindings/python/geniex/generation/config.py
+++ b/bindings/python/geniex/generation/config.py
@@ -29,6 +29,6 @@ class GenerationConfig:
     audios: list[str] = field(default_factory=list)
     stream: bool = False
 
-    # Opt-in ring-buffer context eviction (qairt only). See qcom-ai-hub/geniex#1197.
+    # Opt-in ring-buffer context eviction (qairt only).
     sliding_window: bool = False
     sliding_window_n_keep: int = 0  # 0 = plugin default (4)

--- a/bindings/python/geniex/generation/config.py
+++ b/bindings/python/geniex/generation/config.py
@@ -28,3 +28,7 @@ class GenerationConfig:
     images: list[str] = field(default_factory=list)
     audios: list[str] = field(default_factory=list)
     stream: bool = False
+
+    # Opt-in ring-buffer context eviction (qairt only). See qcom-ai-hub/geniex#1197.
+    sliding_window: bool = False
+    sliding_window_n_keep: int = 0  # 0 = plugin default (4)

--- a/bindings/python/geniex/modeling.py
+++ b/bindings/python/geniex/modeling.py
@@ -76,6 +76,8 @@ def _build_gen_config(
     sampler: geniex_SamplerConfig,
     images: list[str],
     audios: list[str],
+    sliding_window: bool = False,
+    sliding_window_n_keep: int = 0,
 ) -> tuple[geniex_GenerationConfig, object, object, object]:
     # Callers must keep the returned arrays alive until after the C call
     # returns — ctypes does not retain a reference through cast().
@@ -89,6 +91,8 @@ def _build_gen_config(
         sampler_config=pointer(sampler),
         image_count=img_count,
         audio_count=aud_count,
+        sliding_window=sliding_window,
+        sliding_window_n_keep=sliding_window_n_keep,
     )
     if stop_arr is not None:
         cfg.stop = cast(stop_arr, POINTER(c_char_p))
@@ -196,6 +200,9 @@ class GenieXLLM:
         grammar: str | None = None,
         json_mode: bool = False,
         stream: bool = False,
+        # Opt-in ring-buffer context eviction (qairt only).
+        sliding_window: bool = False,
+        sliding_window_n_keep: int = 0,
         **_kwargs,
     ) -> GenerateOutput | TextIteratorStreamer:
         """Generate text from ``prompt``.
@@ -217,7 +224,9 @@ class GenieXLLM:
             grammar,
             json_mode,
         )
-        cfg, _sa, _ia, _aa = _build_gen_config(max_new_tokens, stop, sampler, [], [])
+        cfg, _sa, _ia, _aa = _build_gen_config(
+            max_new_tokens, stop, sampler, [], [], sliding_window, sliding_window_n_keep
+        )
 
         if stream:
             return self._generate_stream(prompt, cfg, sampler, _sa, _ia, _aa)

--- a/cli/README.md
+++ b/cli/README.md
@@ -22,6 +22,23 @@ $env:GENIEX_LOG="debug"            # PowerShell
 
 `NO_COLOR=1` disables ANSI colors.
 
+### Sliding window (qairt only)
+
+The `qairt` backend has a fixed context length (e.g. 4096 tokens). By default, once the accumulated
+conversation history plus a new prompt exceeds it, `geniex infer` returns an out-of-context error and
+the session cannot continue.
+
+Pass `--sliding-window` to opt into evicting the oldest tokens (above a small anchored prefix) instead,
+letting the conversation continue past the context limit:
+
+```bash
+geniex infer <model> --sliding-window
+```
+
+This sets `GENIEX_SLIDING_WINDOW=1` for the process, which the `qairt` plugin reads on every
+`generate()` call; `llama_cpp` ignores it (it always context-shifts). Without the flag, exceeding the
+context length still returns the original error — the feature is strictly opt-in.
+
 ### Model pull
 
 Pull a model non-interactively:

--- a/cli/README.md
+++ b/cli/README.md
@@ -35,9 +35,9 @@ letting the conversation continue past the context limit:
 geniex infer <model> --sliding-window
 ```
 
-This sets `GENIEX_SLIDING_WINDOW=1` for the process, which the `qairt` plugin reads on every
-`generate()` call; `llama_cpp` ignores it (it always context-shifts). Without the flag, exceeding the
-context length still returns the original error — the feature is strictly opt-in.
+This sets `sliding_window: true` on the generation config for every `generate()` call; `llama_cpp`
+ignores it (it always context-shifts). Without the flag, exceeding the context length still returns
+the original error — the feature is strictly opt-in.
 
 ### Model pull
 

--- a/cli/cmd/geniex/infer.go
+++ b/cli/cmd/geniex/infer.go
@@ -38,6 +38,7 @@ var (
 	input          string
 	systemPrompt   string
 	computeUnit    string
+	slidingWindow  bool
 
 	// sampler config
 	temperature       float32
@@ -85,6 +86,7 @@ var (
 		llmFlags.StringVarP(&input, "input", "i", "", "prompt txt file")
 		llmFlags.StringArrayVarP(&prompt, "prompt", "p", nil, "pass prompt")
 		llmFlags.StringVarP(&tokenFile, "token-file", "t", "", "path to token file (space-separated token IDs) (llama_cpp only)")
+		llmFlags.BoolVarP(&slidingWindow, "sliding-window", "", false, "evict oldest context on overflow instead of erroring (qairt only)")
 		return llmFlags
 	}()
 	vlmFlags = func() *pflag.FlagSet {
@@ -267,6 +269,16 @@ func inferLLM(paths *geniex_sdk.ModelPaths) error {
 
 	spin := render.NewSpinner("loading model...")
 	spin.Start()
+
+	// GENIEX_SLIDING_WINDOW is read by the qairt plugin's generate() on every call; llama_cpp
+	// ignores it (it always context-shifts). Set once, before model creation, so it's in effect
+	// for the whole session.
+	if slidingWindow {
+		if setErr := os.Setenv("GENIEX_SLIDING_WINDOW", "1"); setErr != nil {
+			spin.Stop()
+			return fmt.Errorf("failed to set GENIEX_SLIDING_WINDOW: %w", setErr)
+		}
+	}
 
 	p, err := geniex_sdk.NewLLM(geniex_sdk.LlmCreateInput{
 		ModelName: paths.ModelName,

--- a/cli/cmd/geniex/infer.go
+++ b/cli/cmd/geniex/infer.go
@@ -270,16 +270,6 @@ func inferLLM(paths *geniex_sdk.ModelPaths) error {
 	spin := render.NewSpinner("loading model...")
 	spin.Start()
 
-	// GENIEX_SLIDING_WINDOW is read by the qairt plugin's generate() on every call; llama_cpp
-	// ignores it (it always context-shifts). Set once, before model creation, so it's in effect
-	// for the whole session.
-	if slidingWindow {
-		if setErr := os.Setenv("GENIEX_SLIDING_WINDOW", "1"); setErr != nil {
-			spin.Stop()
-			return fmt.Errorf("failed to set GENIEX_SLIDING_WINDOW: %w", setErr)
-		}
-	}
-
 	p, err := geniex_sdk.NewLLM(geniex_sdk.LlmCreateInput{
 		ModelName: paths.ModelName,
 		ModelPath: paths.ModelPath,
@@ -341,6 +331,7 @@ func inferLLM(paths *geniex_sdk.ModelPaths) error {
 					Config: &geniex_sdk.GenerationConfig{
 						MaxTokens:     maxTokens,
 						SamplerConfig: samplerConfig,
+						SlidingWindow: slidingWindow,
 					},
 				})
 				if err != nil {
@@ -369,6 +360,7 @@ func inferLLM(paths *geniex_sdk.ModelPaths) error {
 						MaxTokens:     maxTokens,
 						Stop:          stopSequences,
 						SamplerConfig: samplerConfig,
+						SlidingWindow: slidingWindow,
 					},
 				})
 

--- a/docs/cn/run/cli/reference.mdx
+++ b/docs/cn/run/cli/reference.mdx
@@ -130,6 +130,7 @@ geniex serve
 | `--stop-file` | string | — | 包含停止序列的文件（每行一个）。 |
 | `--think` / `--think=false` | bool | `true` | 启用或禁用推理模型的思考模式。 |
 | `-s`, `--system-prompt` | string | — | 设置模型行为的系统提示。 |
+| `--sliding-window` | — | `false` | （仅 `qairt`）当上下文长度超限时，驱逐锚定前缀之外最旧的上下文，而不是报错，从而让对话继续。会设置 `GENIEX_SLIDING_WINDOW=1`。 |
 
 ## **实用命令**
 

--- a/docs/cn/run/cli/reference.mdx
+++ b/docs/cn/run/cli/reference.mdx
@@ -130,7 +130,7 @@ geniex serve
 | `--stop-file` | string | — | 包含停止序列的文件（每行一个）。 |
 | `--think` / `--think=false` | bool | `true` | 启用或禁用推理模型的思考模式。 |
 | `-s`, `--system-prompt` | string | — | 设置模型行为的系统提示。 |
-| `--sliding-window` | — | `false` | （仅 `qairt`）当上下文长度超限时，驱逐锚定前缀之外最旧的上下文，而不是报错，从而让对话继续。会设置 `GENIEX_SLIDING_WINDOW=1`。 |
+| `--sliding-window` | — | `false` | （仅 `qairt`）当上下文长度超限时，驱逐锚定前缀之外最旧的上下文，而不是报错，从而让对话继续。 |
 
 ## **实用命令**
 

--- a/docs/en/run/cli/reference.mdx
+++ b/docs/en/run/cli/reference.mdx
@@ -130,7 +130,7 @@ Control model loading, context, and generation limits.
 | `--stop-file` | string | — | File containing stop sequences (one per line). |
 | `--think` / `--think=false` | bool | `true` | Enable or disable thinking mode for reasoning models. |
 | `-s`, `--system-prompt` | string | — | System prompt to set model behavior. |
-| `--sliding-window` | — | `false` | (`qairt` only) Evict the oldest context above a small anchored prefix instead of erroring when the context length is exceeded, letting the conversation continue. Sets `GENIEX_SLIDING_WINDOW=1`. |
+| `--sliding-window` | — | `false` | (`qairt` only) Evict the oldest context above a small anchored prefix instead of erroring when the context length is exceeded, letting the conversation continue. |
 
 ## **Utility commands**
 

--- a/docs/en/run/cli/reference.mdx
+++ b/docs/en/run/cli/reference.mdx
@@ -130,6 +130,7 @@ Control model loading, context, and generation limits.
 | `--stop-file` | string | — | File containing stop sequences (one per line). |
 | `--think` / `--think=false` | bool | `true` | Enable or disable thinking mode for reasoning models. |
 | `-s`, `--system-prompt` | string | — | System prompt to set model behavior. |
+| `--sliding-window` | — | `false` | (`qairt` only) Evict the oldest context above a small anchored prefix instead of erroring when the context length is exceeded, letting the conversation continue. Sets `GENIEX_SLIDING_WINDOW=1`. |
 
 ## **Utility commands**
 

--- a/sdk/include/geniex.h
+++ b/sdk/include/geniex.h
@@ -397,6 +397,12 @@ typedef struct {
     int32_t      image_max_length; /* Maximum length of the image */
     geniex_Path* audio_paths;      /* Array of audio paths for VLM (NULL if none) */
     int32_t      audio_count;      /* Number of audios */
+    // --- Context-length overflow handling (qcom-ai-hub/geniex#1197) ---
+    /* qairt only; llama_cpp ignores this (it always context-shifts). When true,
+     * evicts the oldest context tokens above sliding_window_n_keep instead of
+     * erroring on context-length overflow. */
+    bool    sliding_window;
+    int32_t sliding_window_n_keep; /* Tokens to keep anchored when sliding (0 = plugin default of 4) */
 } geniex_GenerationConfig;
 
 /** LLM / VLM model configuration */

--- a/sdk/plugins/qairt/src/llm.cpp
+++ b/sdk/plugins/qairt/src/llm.cpp
@@ -3,7 +3,6 @@
 
 #include "llm.h"
 
-#include <cstdlib>
 #include <cstring>
 #include <exception>
 #include <filesystem>
@@ -35,15 +34,6 @@ namespace {
 // Default system prompt used on the first turn when the caller does not supply one
 // via a `system` role chat message.
 constexpr const char* kDefaultSystemPrompt = "You are a helpful AI assistant.";
-
-// Opt-in ring-buffer context eviction (qcom-ai-hub/geniex#1197). Checked once
-// per generate() call rather than cached, so it can be toggled between turns
-// without recreating the model. GENIEX_SLIDING_WINDOW=1 enables it; unset or
-// any other value keeps the default (throw on context-length overflow).
-bool sliding_window_enabled() {
-    const char* e = std::getenv("GENIEX_SLIDING_WINDOW");
-    return e != nullptr && std::strcmp(e, "1") == 0;
-}
 }  // namespace
 
 QairtLlm::~QairtLlm() = default;
@@ -242,9 +232,15 @@ int32_t QairtLlm::generate(const geniex_LlmGenerateInput* input, geniex_LlmGener
     if (input->config) {
         gen_cfg.max_tokens = input->config->max_tokens > 0 ? input->config->max_tokens : 512;
         qairt::apply_sampler_config(input->config->sampler_config, gen_cfg, bundle_sampler_);
+
+        // Opt-in ring-buffer context eviction. llama_cpp
+        // ignores this field (it always context-shifts).
+        gen_cfg.sliding_window = input->config->sliding_window;
+        if (input->config->sliding_window_n_keep > 0) {
+            gen_cfg.sliding_window_n_keep = input->config->sliding_window_n_keep;
+        }
     }
-    gen_cfg.thinking_mode  = enable_thinking_;
-    gen_cfg.sliding_window = sliding_window_enabled();
+    gen_cfg.thinking_mode = enable_thinking_;
 
     // Wrap token callback
     std::function<bool(const char*)> on_token_fn;

--- a/sdk/plugins/qairt/src/llm.cpp
+++ b/sdk/plugins/qairt/src/llm.cpp
@@ -3,6 +3,7 @@
 
 #include "llm.h"
 
+#include <cstdlib>
 #include <cstring>
 #include <exception>
 #include <filesystem>
@@ -34,6 +35,15 @@ namespace {
 // Default system prompt used on the first turn when the caller does not supply one
 // via a `system` role chat message.
 constexpr const char* kDefaultSystemPrompt = "You are a helpful AI assistant.";
+
+// Opt-in ring-buffer context eviction (qcom-ai-hub/geniex#1197). Checked once
+// per generate() call rather than cached, so it can be toggled between turns
+// without recreating the model. GENIEX_SLIDING_WINDOW=1 enables it; unset or
+// any other value keeps the default (throw on context-length overflow).
+bool sliding_window_enabled() {
+    const char* e = std::getenv("GENIEX_SLIDING_WINDOW");
+    return e != nullptr && std::strcmp(e, "1") == 0;
+}
 }  // namespace
 
 QairtLlm::~QairtLlm() = default;
@@ -233,7 +243,8 @@ int32_t QairtLlm::generate(const geniex_LlmGenerateInput* input, geniex_LlmGener
         gen_cfg.max_tokens = input->config->max_tokens > 0 ? input->config->max_tokens : 512;
         qairt::apply_sampler_config(input->config->sampler_config, gen_cfg, bundle_sampler_);
     }
-    gen_cfg.thinking_mode = enable_thinking_;
+    gen_cfg.thinking_mode  = enable_thinking_;
+    gen_cfg.sliding_window = sliding_window_enabled();
 
     // Wrap token callback
     std::function<bool(const char*)> on_token_fn;


### PR DESCRIPTION
## Summary

Wires the opt-in sliding-window context eviction (`geniex-qairt-plugin` PR [#13](https://github.com/qualcomm/geniex-qairt-plugin/pull/13)) into the public SDK API, the CLI, and every language binding, per qcom-ai-hub/geniex#1197.

- Bumps the `third-party/geniex-qairt` submodule pointer.
- Adds `sliding_window` / `sliding_window_n_keep` fields to `geniex_GenerationConfig` (`sdk/include/geniex.h`), read directly by `QairtLlm::generate()`. `llama_cpp` ignores these fields (it always context-shifts).
- Adds a `--sliding-window` flag to `geniex infer`, passed through the typed config on every `Generate()` call.
- Updates every binding's FFI surface in this change (per `CONTRIBUTING.md`): Go (`bindings/go`), Python (`bindings/python`), Android (`bindings/android`).
- Documents the flag in `cli/README.md` and `docs/{en,cn}/run/cli/reference.mdx`.

## Why a typed config field instead of an env var

An earlier version of this PR read an env var (`GENIEX_SLIDING_WINDOW=1`, set via `os.Setenv()` from the Go CLI) directly in the plugin. This had a real bug on Windows: `os.Setenv()` called at runtime from Go is not guaranteed to be visible to a separately-CRT-linked plugin DLL (each DLL's CRT can hold its own environment-block snapshot) -- `--sliding-window` was silently non-functional unless the env var was also exported in the parent shell *before* launching the process.

Moving the flag onto `geniex_GenerationConfig` fixes this (same in-process struct pointer already used for `max_tokens`/`sampler_config`) and, per review feedback, makes the feature available to the Python and Android bindings as well, not just the Go CLI.

## Submodule bump also picks up an EOS-detection fix and a CJK detokenizer fix

The latest `third-party/geniex-qairt` submodule bump in this branch also picks up two unrelated fixes from that repo's history:

- **EOS-detection fix** (geniex-qairt-plugin@a723e23): PR #12 (graph-info refactor) introduced `LLMModel(buildSpecSkeleton(gc), std::move(gc))` in every plain-LLM model factory -- an unsequenced pair of arguments that could leave `eos_token_ids` empty depending on evaluation order, causing generation to never stop at EOS and instead always run to `max_tokens`. See geniex-qairt-plugin#13 for the full root cause and fix; verified on real hardware via the Go CLI that generation now stops cleanly at EOS again.
- **CJK detokenizer fix**: the submodule's own `third-party/geniex-proc` submodule was bumped past PR [qualcomm/geniex-proc#10](https://github.com/qualcomm/geniex-proc/pull/10) ("fix: extend byte-level reverse table to U+0143 to fix CJK detok"), which fixes #1140 -- CJK output on the qairt (NPU) runtime being corrupted into mojibake (e.g. `中国` → `ä¸ŃåĽ½`). Root cause was a byte-level fallback reverse-table that only covered up to a certain code point; CJK byte-fallback tokens beyond that range detokenized incorrectly.

## Acceptance criteria (qcom-ai-hub/geniex#1197)

- [x] Default behavior is preserved: exceeding the context length without opt-in returns the existing out-of-context error.
- [x] Passing `--sliding-window` to the CLI enables ring-buffer eviction.
- [x] With sliding window enabled, conversations continue past the context limit by evicting the oldest context -- verified end-to-end on real QAIRT hardware (see geniex-qairt-plugin#13), including the case where eviction fires mid-turn and the conversation continues coherently into the next turn.
- [x] Available to all bindings (Go, Python, Android), not just the CLI.
- [x] Document the flag in CLI help / docs.

## Testing

- Rebuilt the SDK bridge + qairt plugin (`cmake --build`) and the Go CLI (`bazelisk build //cli --config=windows_arm64`) -- clean builds.
- `clang-format`, `ruff check`/`ruff format --check` on all touched files -- clean.
- Ran `geniex infer qualcomm/Qwen3-4B-Instruct-2507 --sliding-window` on real hardware with `GENIEX_SLIDING_WINDOW` unset from the environment (confirming the old env-var dependency is gone): eviction fires (`sliding window: discarding N tokens...`), generation continues with no `context length exceeded` error, and the model stops cleanly at EOS on both short and long turns.

## Related

- qualcomm/geniex-qairt-plugin#13 (core re-prefill eviction implementation + EOS-detection fix)
- Fixes #1140 (CJK detokenizer mojibake on the qairt runtime), via qualcomm/geniex-proc#10
