### PR TITLE
feat(sdk): add ignore_eos to force full-length decode in geniex-bench

### DIFF
--- a/bindings/android/app/src/main/cpp/jniutils.cpp
+++ b/bindings/android/app/src/main/cpp/jniutils.cpp
@@ -152,6 +152,10 @@ geniex_GenerationConfig extract_generation_config(JNIEnv* env, jobject configObj
     cfg.audio_paths = audioPathPtrs.empty() ? nullptr : (geniex_Path*)audioPathPtrs.data();
     cfg.audio_count = audioPathPtrs.size();
 
+    // ----------- ignoreEos -----------
+    jfieldID ignoreEosId = env->GetFieldID(cls, "ignoreEos", "Z");
+    cfg.ignore_eos       = ignoreEosId ? env->GetBooleanField(configObj, ignoreEosId) : false;
+
     return cfg;
 }
 

--- a/bindings/android/app/src/main/java/com/geniex/sdk/bean/GenerationConfig.kt
+++ b/bindings/android/app/src/main/java/com/geniex/sdk/bean/GenerationConfig.kt
@@ -10,5 +10,6 @@ data class GenerationConfig(
     var imagePaths: Array<String>? = null,
     var imageCount: Int = 0,
     var audioPaths: Array<String>? = null,
-    var audioCount: Int = 0
+    var audioCount: Int = 0,
+    var ignoreEos: Boolean = false
 )

--- a/bindings/go/common.go
+++ b/bindings/go/common.go
@@ -104,6 +104,7 @@ type GenerationConfig struct {
 	ImagePaths     []string
 	ImageMaxLength int32
 	AudioPaths     []string
+	IgnoreEos      bool
 }
 
 // LCOV_EXCL_START
@@ -113,6 +114,7 @@ func (gc GenerationConfig) toCPtr() *C.geniex_GenerationConfig {
 		max_tokens:       C.int32_t(gc.MaxTokens),
 		n_past:           C.int32_t(gc.NPast),
 		image_max_length: C.int32_t(gc.ImageMaxLength),
+		ignore_eos:       C.bool(gc.IgnoreEos),
 	}
 
 	if len(gc.Stop) > 0 {

--- a/bindings/python/geniex/_ffi/_types.py
+++ b/bindings/python/geniex/_ffi/_types.py
@@ -82,6 +82,7 @@ class geniex_GenerationConfig(Structure):
         ('image_max_length', c_int32),
         ('audio_paths', POINTER(c_char_p)),
         ('audio_count', c_int32),
+        ('ignore_eos', c_bool),
     ]
 
 

--- a/sdk/benchmark/benchmark.c
+++ b/sdk/benchmark/benchmark.c
@@ -103,6 +103,7 @@ typedef struct {
     int32_t repeat;
     bool    reset_between_runs; /* true => geniex_llm_reset() before each run, freeing KV */
     bool    accuracy;           /* true => single run (warmup=0, repeat=1), print generated text */
+    bool    ignore_eos;         /* true => keep generating past EOS so decode always runs n_gen (llama_cpp only) */
     int32_t n_ctx;
     int32_t n_threads;
     int32_t ngl_override; /* -1 = use resolved alias default; >=0 overrides */
@@ -218,6 +219,9 @@ static void usage(const char* argv0) {
         "                         device alias default (needed for a real gpu run)\n"
         "  --warmup N             default 1\n"
         "  --no-warmup            equivalent to --warmup 0\n"
+        "  --ignore-eos           keep generating past EOS so decode always runs the\n"
+        "                         full --n-gen tokens (llama_cpp only; no-op on qairt).\n"
+        "                         Reported stop_reason becomes \"length\".\n"
         "  --temperature F        default 0.0\n"
         "  --seed N               default 42; also seeds rand() for prompt ids\n"
         "  --prompt-file PATH     opt out of random-ids prefill: read a UTF-8 prompt\n"
@@ -625,6 +629,7 @@ static void parse_args(int argc, char** argv, options_t* o) {
     o->repeat             = 5;
     o->reset_between_runs = true;
     o->accuracy           = false;
+    o->ignore_eos         = false;
     o->n_ctx              = 0;
     o->n_threads          = 0;
     o->ngl_override       = -1;
@@ -682,6 +687,8 @@ static void parse_args(int argc, char** argv, options_t* o) {
             o->warmup = atoi(arg_value(argc, argv, &i, a));
         } else if (strcmp(a, "--no-warmup") == 0) {
             o->warmup = 0;
+        } else if (strcmp(a, "--ignore-eos") == 0) {
+            o->ignore_eos = true;
         } else if (strcmp(a, "-r") == 0 || strcmp(a, "--repetitions") == 0) {
             o->repeat = atoi(arg_value(argc, argv, &i, a));
         } else if (strcmp(a, "--no-reset-between-runs") == 0) {
@@ -955,6 +962,7 @@ static void fill_gen_config(geniex_GenerationConfig* g, geniex_SamplerConfig* s,
     memset(g, 0, sizeof(*g));
     g->max_tokens     = o->max_new_tokens;
     g->sampler_config = s;
+    g->ignore_eos     = o->ignore_eos;
     if (with_media && o->image_count > 0) {
         g->image_paths = (geniex_Path*)o->image_paths;
         g->image_count = o->image_count;

--- a/sdk/include/geniex.h
+++ b/sdk/include/geniex.h
@@ -397,6 +397,7 @@ typedef struct {
     int32_t      image_max_length; /* Maximum length of the image */
     geniex_Path* audio_paths;      /* Array of audio paths for VLM (NULL if none) */
     int32_t      audio_count;      /* Number of audios */
+    bool         ignore_eos;       /* Continue generating past EOS/EOG (bench reproducibility) */
 } geniex_GenerationConfig;
 
 /** LLM / VLM model configuration */

--- a/sdk/plugins/llama_cpp/src/llm.cpp
+++ b/sdk/plugins/llama_cpp/src/llm.cpp
@@ -356,8 +356,8 @@ int32_t LlamaLlm::generate(const geniex_LlmGenerateInput* input, geniex_LlmGener
             GENIEX_LOG_DEBUG("First token generated, TTFT recorded");
         }
 
-        // Check EOS token
-        if (llama_vocab_is_eog(vocab, id)) {
+        // Check EOS token (skipped when ignore_eos forces a full-length run)
+        if (!cfg.ignore_eos && llama_vocab_is_eog(vocab, id)) {
             GENIEX_LOG_DEBUG("EOS token generated, stopping generation");
             profiler.set_stop_reason(common::StopReason::GENIEX_STOP_REASON_EOS);
             break;

--- a/sdk/plugins/llama_cpp/src/vlm.cpp
+++ b/sdk/plugins/llama_cpp/src/vlm.cpp
@@ -393,7 +393,7 @@ int32_t LlamaVlm::generate(const geniex_VlmGenerateInput* input, geniex_VlmGener
         // Accept the token first (like mtmd-cli.cpp does)
         common_sampler_accept(this->sampler, token, true);
 
-        if (llama_vocab_is_eog(vocab, token)) {
+        if (!cfg.ignore_eos && llama_vocab_is_eog(vocab, token)) {
             GENIEX_LOG_DEBUG("reached end of generation token");
             profiler.set_stop_reason(common::StopReason::GENIEX_STOP_REASON_EOS);
             break;


### PR DESCRIPTION
## Summary

Adds an `--ignore-eos` option to `geniex-bench` that keeps generation running
past EOS/EOG so decode always produces the full `--n-gen` tokens. This makes
decode-speed numbers comparable across models that would otherwise stop early,
mirroring `llama-bench --ignore-eos`.

The whole behavioral change is one guard in the llama_cpp decode loop; the rest
is plumbing a single `bool` through the one public conduit that reaches it.

### Changes

- **`sdk/include/geniex.h`** — append `bool ignore_eos` to `geniex_GenerationConfig` (field appended at the end, so existing offsets are unchanged).
- **`sdk/plugins/llama_cpp/src/{llm,vlm}.cpp`** — guard the `llama_vocab_is_eog` break with `!cfg.ignore_eos`. When set, the EOG token falls through, the loop runs to `max_tokens`, and `stop_reason` becomes `"length"` via the existing post-loop path. Both the text-LLM and VLM decode loops are covered.
- **`sdk/benchmark/benchmark.c`** — `--ignore-eos` flag → `options_t` → `fill_gen_config`, plus help text.
- **FFI mirrors** (required by CONTRIBUTING.md §4 — public header changed):
  - Python ctypes `_types.py` — append `('ignore_eos', c_bool)` (**correctness-critical**: the SDK copies `*config` by value, so a shorter Structure would read past the allocation).
  - Go `common.go` — `IgnoreEos bool` + wire into `toCPtr()`.
  - Android JNI `jniutils.cpp` + Kotlin `GenerationConfig.kt` — read `ignoreEos`.

### qairt

qairt drives EOS inside the third-party genie engine
(`third-party/geniex-qairt/.../llm_model.cpp`), which has no ignore-eos seam and
must not be modified. The flag is therefore a **documented no-op on qairt** — the
plugin simply ignores the new field, consistent with how it already ignores
`--ngl` / `--n-ctx` / `--stop`.

## Test plan

- [x] `geniex.h` field compiles; a C consumer can set `g.ignore_eos = true`.
- [x] `benchmark.c` passes `gcc -fsyntax-only`.
- [x] Python `_types.py` loads; `geniex_GenerationConfig._fields_` ends with `ignore_eos` and set/get round-trips.
- [x] `bindings/go/common.go` is `gofmt`-clean.
- [x] `clang-format`, `ruff check`, `ruff format --check` clean on touched files (pre-existing unrelated format drift in `llm.cpp` left untouched).
- [ ] Full SDK bridge build + on-device bench run (`--ignore-eos` yields `gen == n_gen` and `stop_reason == "length"`) — pending, needs the toolchain container / device.
