### PR TITLE
feat(sdk): load custom QNN library via GENIEX_QNN_LIB / --qnn-lib

### DIFF
--- a/cli/cmd/geniex/infer.go
+++ b/cli/cmd/geniex/infer.go
@@ -76,7 +76,7 @@ var (
 		llmFlags := pflag.NewFlagSet("LLM/VLM Model", pflag.ExitOnError)
 		llmFlags.SortFlags = false
 		llmFlags.StringVarP(&computeUnit, "compute", "c", "", "compute unit to run on: cpu, gpu, npu, or hybrid (default: hybrid for llama_cpp, npu for qairt)")
-		llmFlags.StringVarP(&qnnLib, "qnn-lib", "", "", "path to a folder holding custom QNN libraries (qairt only; overrides GENIEX_QNN_LIB, default: bundled QNN-lib)")
+		llmFlags.StringVarP(&qnnLib, "qnn-lib", "", "", "QAIRT SDK root or lib folder for testing a custom QNN build (qairt only; sets GENIEX_QNN_LIB; may crash on ABI-incompatible QAIRT versions; default: bundled QNN-lib)")
 		llmFlags.Int32VarP(&ngl, "ngl", "n", 0, "number of layers to offload to gpu/npu (llama_cpp only, default 999)")
 		llmFlags.Int32VarP(&nctx, "nctx", "", 0, "context window size (llama_cpp only, default 4096)")
 		llmFlags.Int32VarP(&maxTokens, "max-tokens", "", 2048, "max tokens")

--- a/cli/cmd/geniex/infer.go
+++ b/cli/cmd/geniex/infer.go
@@ -38,6 +38,7 @@ var (
 	input          string
 	systemPrompt   string
 	computeUnit    string
+	qnnLib         string
 
 	// sampler config
 	temperature       float32
@@ -75,6 +76,7 @@ var (
 		llmFlags := pflag.NewFlagSet("LLM/VLM Model", pflag.ExitOnError)
 		llmFlags.SortFlags = false
 		llmFlags.StringVarP(&computeUnit, "compute", "c", "", "compute unit to run on: cpu, gpu, npu, or hybrid (default: hybrid for llama_cpp, npu for qairt)")
+		llmFlags.StringVarP(&qnnLib, "qnn-lib", "", "", "path to a folder holding custom QNN libraries (qairt only; overrides GENIEX_QNN_LIB, default: bundled QNN-lib)")
 		llmFlags.Int32VarP(&ngl, "ngl", "n", 0, "number of layers to offload to gpu/npu (llama_cpp only, default 999)")
 		llmFlags.Int32VarP(&nctx, "nctx", "", 0, "context window size (llama_cpp only, default 4096)")
 		llmFlags.Int32VarP(&maxTokens, "max-tokens", "", 2048, "max tokens")
@@ -120,6 +122,15 @@ func infer() *cobra.Command {
 		paths, err := ensureModelAvailable(cmd.Context(), name, precision)
 		if err != nil {
 			return err
+		}
+
+		// --qnn-lib is a convenience wrapper over the GENIEX_QNN_LIB env var the qairt
+		// plugin reads at model-load time. Exporting it here means both the LLM and VLM
+		// paths (and any binding that shares this process) pick it up uniformly.
+		if qnnLib != "" {
+			if err := os.Setenv("GENIEX_QNN_LIB", qnnLib); err != nil {
+				return fmt.Errorf("failed to set GENIEX_QNN_LIB: %w", err)
+			}
 		}
 
 		geniex_sdk.Init()

--- a/notes/run.md
+++ b/notes/run.md
@@ -113,10 +113,18 @@ QAIRT models need a `geniex.json` to work. See the [granite4_micro example](http
 
 ### Using a custom QNN library
 
+> [!WARNING]
+> **Testing/validation aid — not a general version-mixing feature.** GenieX's QAIRT plugin
+> is compiled against a specific set of QAIRT headers, and QAIRT is not currently guaranteed
+> to be ABI-stable across versions. Loading a QNN build whose struct layouts, field offsets,
+> or vtables differ can **segfault** on the first changed code path — it will appear to work on
+> unchanged paths and crash on changed ones (see ai-hub-models-internal#3964). Use this to
+> validate a specific candidate QAIRT build before bundling it into a GenieX `.alpha`/RC, not
+> to run against arbitrary installed QAIRT versions in production.
+
 By default the QAIRT plugin loads the QNN shared libraries bundled with the GenieX
-release. To validate a different QAIRT/QNN build without reinstalling — e.g. to run a
-GenieX build against several installed QAIRT SDK versions — point the plugin at the
-library location:
+release. To validate a different QAIRT/QNN build without reinstalling, point the plugin at
+the library location:
 
 ```bash
 # via the CLI flag (qairt models only)

--- a/notes/run.md
+++ b/notes/run.md
@@ -111,6 +111,27 @@ Warning: qairt plugin only supports NPU inference; ignoring device='cpu' and run
 
 QAIRT models need a `geniex.json` to work. See the [granite4_micro example](https://huggingface.co/yichqian/geniex-qairt-models/blob/main/granite4_micro/geniex.json).
 
+### Using a custom QNN library
+
+By default the QAIRT plugin loads the QNN shared libraries bundled with the GenieX
+release. To validate a different QAIRT/QNN build without reinstalling, point the plugin
+at a folder that directly contains the QNN libraries (`QnnHtp.dll` / `QnnSystem.dll` /
+`QnnHtpNetRunExtensions.dll` on Windows, the `libQnn*.so` equivalents on Linux/Android):
+
+```bash
+# via the CLI flag (qairt models only)
+geniex infer local/granite4_micro --qnn-lib /path/to/custom-qnn-libs
+
+# or via the environment variable (picked up by any front-end: CLI, pybind, Android)
+GENIEX_QNN_LIB=/path/to/custom-qnn-libs geniex infer local/granite4_micro
+```
+
+`--qnn-lib` is a convenience wrapper that sets `GENIEX_QNN_LIB` for the process; the flag
+wins when both are given. The path must be a directory containing at least the backend
+library — otherwise model load fails fast with a clear error (e.g. `GENIEX_QNN_LIB does not
+contain QnnHtp.dll: <path>`). When neither the flag nor the env var is set, behavior is
+unchanged and the bundled QNN-lib is used.
+
 ### Build and run locally
 
 ```bash

--- a/notes/run.md
+++ b/notes/run.md
@@ -114,23 +114,34 @@ QAIRT models need a `geniex.json` to work. See the [granite4_micro example](http
 ### Using a custom QNN library
 
 By default the QAIRT plugin loads the QNN shared libraries bundled with the GenieX
-release. To validate a different QAIRT/QNN build without reinstalling, point the plugin
-at a folder that directly contains the QNN libraries (`QnnHtp.dll` / `QnnSystem.dll` /
-`QnnHtpNetRunExtensions.dll` on Windows, the `libQnn*.so` equivalents on Linux/Android):
+release. To validate a different QAIRT/QNN build without reinstalling — e.g. to run a
+GenieX build against several installed QAIRT SDK versions — point the plugin at the
+library location:
 
 ```bash
 # via the CLI flag (qairt models only)
-geniex infer local/granite4_micro --qnn-lib /path/to/custom-qnn-libs
+geniex infer local/granite4_micro --qnn-lib /path/to/qairt/2.XX.0
 
 # or via the environment variable (picked up by any front-end: CLI, pybind, Android)
-GENIEX_QNN_LIB=/path/to/custom-qnn-libs geniex infer local/granite4_micro
+GENIEX_QNN_LIB=/path/to/qairt/2.XX.0 geniex infer local/granite4_micro
 ```
 
+The path accepts either layout:
+
+- **A QAIRT SDK root** (as installed from the Qualcomm Software Center). The plugin resolves
+  the host libraries from `lib/<triple>` (`aarch64-windows-msvc`, `aarch64-android`, or
+  `aarch64-oe-linux-gcc11.2`) and points `ADSP_LIBRARY_PATH` at every Hexagon DSP skel folder
+  (`lib/hexagon-v*/unsigned`), so the on-device HTP arch is matched automatically. This mirrors
+  the manual env-var setup in the [llm_on_genie tutorial](https://github.com/qualcomm/ai-hub-apps/tree/main/tutorials/llm_on_genie#windows-powershell).
+- **A flat folder** that directly holds `QnnHtp.dll` / `QnnSystem.dll` /
+  `QnnHtpNetRunExtensions.dll` (or the `libQnn*.so` equivalents) — the same shape as the
+  bundled `htp-files` layout.
+
 `--qnn-lib` is a convenience wrapper that sets `GENIEX_QNN_LIB` for the process; the flag
-wins when both are given. The path must be a directory containing at least the backend
-library — otherwise model load fails fast with a clear error (e.g. `GENIEX_QNN_LIB does not
-contain QnnHtp.dll: <path>`). When neither the flag nor the env var is set, behavior is
-unchanged and the bundled QNN-lib is used.
+wins when both are given. If no backend library is found under either layout, model load
+fails fast with a clear error (e.g. `GENIEX_QNN_LIB does not contain QnnHtp.dll (looked in
+the folder itself and lib/aarch64-windows-msvc): <path>`). When neither the flag nor the env
+var is set, behavior is unchanged and the bundled QNN-lib is used.
 
 ### Build and run locally
 

--- a/sdk/plugins/qairt/include/qnn_runtime_utils.h
+++ b/sdk/plugins/qairt/include/qnn_runtime_utils.h
@@ -68,25 +68,96 @@ inline std::optional<std::string> find_optional_file(const std::filesystem::path
     return std::nullopt;
 }
 
-// Platform-specific base names of the three QNN shared libraries the QAIRT plugin loads.
-#ifdef _WIN32
+// Platform-specific base names of the three QNN shared libraries the QAIRT plugin loads,
+// the host-lib subfolder they live in inside a QAIRT SDK install, and the OS PATH separator.
+#if defined(_WIN32)
 constexpr const char* kQnnBackendLib    = "QnnHtp.dll";
 constexpr const char* kQnnSystemLib     = "QnnSystem.dll";
 constexpr const char* kQnnExtensionsLib = "QnnHtpNetRunExtensions.dll";
-#else  // __ANDROID__ and __linux__
+constexpr const char* kHostLibTriple    = "aarch64-windows-msvc";
+constexpr char        kPathSep          = ';';
+#elif defined(__ANDROID__)
 constexpr const char* kQnnBackendLib    = "libQnnHtp.so";
 constexpr const char* kQnnSystemLib     = "libQnnSystem.so";
 constexpr const char* kQnnExtensionsLib = "libQnnHtpNetRunExtensions.so";
+constexpr const char* kHostLibTriple    = "aarch64-android";
+constexpr char        kPathSep          = ':';
+#else  // __linux__
+constexpr const char* kQnnBackendLib    = "libQnnHtp.so";
+constexpr const char* kQnnSystemLib     = "libQnnSystem.so";
+constexpr const char* kQnnExtensionsLib = "libQnnHtpNetRunExtensions.so";
+constexpr const char* kHostLibTriple    = "aarch64-oe-linux-gcc11.2";
+constexpr char        kPathSep          = ':';
 #endif
+
+// Given a user-supplied QNN lib location, returns the directory that actually holds the
+// host QNN libraries (kQnnBackendLib). Handles both a flat folder (libs sit directly in
+// `root`, our bundled htp-files layout) and a full QAIRT SDK install, where the host libs
+// live under `root/lib/<triple>`. Returns an empty path when none is found.
+inline std::filesystem::path locate_qnn_host_lib_dir(const std::filesystem::path& root) {
+    namespace fs = std::filesystem;
+    std::error_code ec;
+
+    // Flat folder: libs directly inside root.
+    if (fs::exists(root / kQnnBackendLib, ec)) return root;
+
+    // QAIRT SDK: canonical per-platform triple.
+    const fs::path triple_dir = root / "lib" / kHostLibTriple;
+    if (fs::exists(triple_dir / kQnnBackendLib, ec)) return triple_dir;
+
+    // Fallback: scan lib/* for any subfolder carrying the backend lib. Covers QAIRT
+    // triples that vary across SDK versions (e.g. differing Linux gcc suffixes). Hexagon
+    // skel folders never contain the host backend lib, so they are naturally skipped.
+    const fs::path lib_dir = root / "lib";
+    if (fs::is_directory(lib_dir, ec)) {
+        for (const auto& entry : fs::directory_iterator(lib_dir, ec)) {
+            if (entry.is_directory(ec) && fs::exists(entry.path() / kQnnBackendLib, ec)) {
+                return entry.path();
+            }
+        }
+    }
+    return {};
+}
+
+// Collects the Hexagon DSP skel folders that ADSP_LIBRARY_PATH must point at inside a QAIRT
+// SDK: every `root/lib/hexagon-v*/unsigned` (or the arch folder itself when there is no
+// `unsigned` subdir), joined with the platform PATH separator. All arch variants are listed
+// so QNN's loader selects the one matching the on-device HTP arch. Empty when none exist
+// (flat-folder override, where the skels sit alongside the host libs).
+inline std::string collect_adsp_library_path(const std::filesystem::path& root) {
+    namespace fs = std::filesystem;
+    std::error_code          ec;
+    std::vector<std::string> dirs;
+
+    const fs::path lib_dir = root / "lib";
+    if (fs::is_directory(lib_dir, ec)) {
+        for (const auto& entry : fs::directory_iterator(lib_dir, ec)) {
+            if (!entry.is_directory(ec)) continue;
+            if (entry.path().filename().string().rfind("hexagon-", 0) != 0) continue;
+            const fs::path unsigned_dir = entry.path() / "unsigned";
+            dirs.push_back(fs::is_directory(unsigned_dir, ec) ? unsigned_dir.string() : entry.path().string());
+        }
+    }
+
+    std::sort(dirs.begin(), dirs.end());
+    std::string joined;
+    for (const auto& d : dirs) {
+        if (!joined.empty()) joined.push_back(kPathSep);
+        joined += d;
+    }
+    return joined;
+}
 
 // Returns a QnnRuntimeConfig for the given model directory.
 //
 // QNN library resolution, in priority order:
-//   1. GENIEX_QNN_LIB env var (set directly or via the CLI `--qnn-lib` flag) — points at a
-//      folder that directly contains the QNN shared libraries. Lets a single GenieX release
-//      run against an arbitrary QAIRT/QNN build without reinstalling. Validated eagerly:
-//      a missing folder or a folder without the backend library throws std::runtime_error
-//      so the caller surfaces a clear message instead of a late dlopen failure.
+//   1. GENIEX_QNN_LIB env var (set directly or via the CLI `--qnn-lib` flag). Lets a single
+//      GenieX release run against an arbitrary QAIRT/QNN build without reinstalling. The value
+//      may be either a full QAIRT SDK root (host libs under `lib/<triple>`, Hexagon DSP skels
+//      under `lib/hexagon-v*/unsigned`) or a flat folder holding the libs directly. Host-lib
+//      and DSP-skel locations are resolved separately because a real QAIRT SDK does not colocate
+//      them. Validated eagerly: if no host backend library is found the load fails fast with a
+//      std::runtime_error so the caller surfaces a clear message instead of a late dlopen error.
 //   2. GENIEX_PLUGIN_PATH env var — the bundled layout, libraries under `<path>/qairt/htp-files`
 //      (flattened to `<path>` on Android).
 //   3. Neither set — fall back to bare library names so the OS loader resolves them from its
@@ -96,30 +167,39 @@ inline QnnRuntimeConfig make_qnn_runtime_config(const std::filesystem::path& mod
 
     QnnRuntimeConfig runtime_cfg{};
 
-    // (1) Explicit override: GENIEX_QNN_LIB folder holds the QNN libs directly.
-    const fs::path qnn_lib_dir = read_env_path("GENIEX_QNN_LIB", L"GENIEX_QNN_LIB");
-    if (!qnn_lib_dir.empty()) {
+    // (1) Explicit override: GENIEX_QNN_LIB points at a QAIRT SDK root or a flat lib folder.
+    const fs::path qnn_lib_root = read_env_path("GENIEX_QNN_LIB", L"GENIEX_QNN_LIB");
+    if (!qnn_lib_root.empty()) {
         std::error_code ec;
-        if (!fs::is_directory(qnn_lib_dir, ec)) {
-            throw std::runtime_error("GENIEX_QNN_LIB path is not a directory: " + qnn_lib_dir.string());
+        if (!fs::is_directory(qnn_lib_root, ec)) {
+            throw std::runtime_error("GENIEX_QNN_LIB path is not a directory: " + qnn_lib_root.string());
         }
-        const fs::path backend = qnn_lib_dir / kQnnBackendLib;
-        if (!fs::exists(backend, ec)) {
-            throw std::runtime_error(
-                "GENIEX_QNN_LIB does not contain " + std::string(kQnnBackendLib) + ": " + qnn_lib_dir.string());
+        const fs::path host_dir = locate_qnn_host_lib_dir(qnn_lib_root);
+        if (host_dir.empty()) {
+            throw std::runtime_error("GENIEX_QNN_LIB does not contain " + std::string(kQnnBackendLib) +
+                                     " (looked in the folder itself and lib/" + kHostLibTriple +
+                                     "): " + qnn_lib_root.string());
         }
 
-        GENIEX_LOG_INFO("Using custom QNN libraries from GENIEX_QNN_LIB: {}", qnn_lib_dir.string());
-        GENIEX_LOG_DEBUG("Setting ADSP_LIBRARY_PATH to {}", qnn_lib_dir.string());
+        // ADSP_LIBRARY_PATH points at the Hexagon DSP skel folders. In a QAIRT SDK these live
+        // apart from the host libs; if none are found (flat folder) fall back to the host dir,
+        // which is also where our bundled skels sit.
+        std::string adsp_path = collect_adsp_library_path(qnn_lib_root);
+        if (adsp_path.empty()) adsp_path = host_dir.string();
+
+        GENIEX_LOG_INFO("Using custom QNN libraries from GENIEX_QNN_LIB: {} (host libs: {})",
+            qnn_lib_root.string(),
+            host_dir.string());
+        GENIEX_LOG_DEBUG("Setting ADSP_LIBRARY_PATH to {}", adsp_path);
 #if defined(WIN32)
-        _putenv_s("ADSP_LIBRARY_PATH", qnn_lib_dir.string().c_str());
-        SetDllDirectoryA(qnn_lib_dir.string().c_str());
+        _putenv_s("ADSP_LIBRARY_PATH", adsp_path.c_str());
+        SetDllDirectoryA(host_dir.string().c_str());
 #else
-        setenv("ADSP_LIBRARY_PATH", qnn_lib_dir.string().c_str(), 1);
+        setenv("ADSP_LIBRARY_PATH", adsp_path.c_str(), 1);
 #endif
-        runtime_cfg.backend_path    = backend.string();
-        runtime_cfg.system_lib_path = (qnn_lib_dir / kQnnSystemLib).string();
-        runtime_cfg.extensions_path = (qnn_lib_dir / kQnnExtensionsLib).string();
+        runtime_cfg.backend_path    = (host_dir / kQnnBackendLib).string();
+        runtime_cfg.system_lib_path = (host_dir / kQnnSystemLib).string();
+        runtime_cfg.extensions_path = (host_dir / kQnnExtensionsLib).string();
 
         static_cast<void>(model_dir);  // reserved for future fallback logic
         return runtime_cfg;

--- a/sdk/plugins/qairt/include/qnn_runtime_utils.h
+++ b/sdk/plugins/qairt/include/qnn_runtime_utils.h
@@ -187,6 +187,15 @@ inline QnnRuntimeConfig make_qnn_runtime_config(const std::filesystem::path& mod
         std::string adsp_path = collect_adsp_library_path(qnn_lib_root);
         if (adsp_path.empty()) adsp_path = host_dir.string();
 
+        // QAIRT is not guaranteed ABI-stable across versions: this plugin is compiled against
+        // a specific set of QAIRT headers, so loading a QNN build whose struct layouts / vtables
+        // differ can segfault on the first changed code path (see ai-hub-models-internal#3964).
+        // Overriding the bundled libraries is therefore a testing/validation aid, not a supported
+        // way to mix arbitrary QAIRT versions — warn loudly so a later crash is easy to trace.
+        GENIEX_LOG_WARN(
+            "GENIEX_QNN_LIB override active: loading QNN libraries from {} instead of the bundled set. "
+            "This is intended for testing a specific QAIRT build; an ABI-incompatible QAIRT version may crash.",
+            qnn_lib_root.string());
         GENIEX_LOG_INFO("Using custom QNN libraries from GENIEX_QNN_LIB: {} (host libs: {})",
             qnn_lib_root.string(),
             host_dir.string());

--- a/sdk/plugins/qairt/include/qnn_runtime_utils.h
+++ b/sdk/plugins/qairt/include/qnn_runtime_utils.h
@@ -11,12 +11,38 @@
 #include <cstdlib>
 #include <filesystem>
 #include <optional>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
 #include "types.h"
 
 namespace geniex::qairt::runtime {
+
+// Reads an environment variable as a filesystem path, returning an empty path when
+// it is unset or empty. On Windows the wide-char API is used so Unicode paths round-trip
+// correctly (the narrow name is ignored there and vice versa on POSIX).
+inline std::filesystem::path read_env_path(const char* name_utf8, const wchar_t* name_wide) {
+#if defined(_WIN32)
+    static_cast<void>(name_utf8);
+    size_t required_size = 0;
+    _wgetenv_s(&required_size, nullptr, 0, name_wide);
+    if (required_size > 0) {
+        std::vector<wchar_t> env_buffer(required_size);
+        _wgetenv_s(&required_size, env_buffer.data(), required_size, name_wide);
+        if (env_buffer[0] != L'\0') {
+            return std::filesystem::path(env_buffer.data());
+        }
+    }
+    return {};
+#else   // _WIN32
+    static_cast<void>(name_wide);
+    if (const char* value = std::getenv(name_utf8)) {
+        return std::filesystem::path(value);
+    }
+    return {};
+#endif  // _WIN32
+}
 
 inline std::vector<std::string> collect_bin_files(const std::filesystem::path& dir) {
     std::vector<std::string> bins;
@@ -42,35 +68,65 @@ inline std::optional<std::string> find_optional_file(const std::filesystem::path
     return std::nullopt;
 }
 
-// Returns a QnnRuntimeConfig for the given model directory and optional user-supplied
-// QNN lib folder path.
+// Platform-specific base names of the three QNN shared libraries the QAIRT plugin loads.
+#ifdef _WIN32
+constexpr const char* kQnnBackendLib    = "QnnHtp.dll";
+constexpr const char* kQnnSystemLib     = "QnnSystem.dll";
+constexpr const char* kQnnExtensionsLib = "QnnHtpNetRunExtensions.dll";
+#else  // __ANDROID__ and __linux__
+constexpr const char* kQnnBackendLib    = "libQnnHtp.so";
+constexpr const char* kQnnSystemLib     = "libQnnSystem.so";
+constexpr const char* kQnnExtensionsLib = "libQnnHtpNetRunExtensions.so";
+#endif
+
+// Returns a QnnRuntimeConfig for the given model directory.
 //
-// If qnn_lib_folder_path is non-empty, the three HTP runtime path fields are set
-// explicitly to that directory (user override). Otherwise all path fields are left
-// as std::nullopt to let geniex_qairt resolve them automatically at runtime (default behavior).
+// QNN library resolution, in priority order:
+//   1. GENIEX_QNN_LIB env var (set directly or via the CLI `--qnn-lib` flag) — points at a
+//      folder that directly contains the QNN shared libraries. Lets a single GenieX release
+//      run against an arbitrary QAIRT/QNN build without reinstalling. Validated eagerly:
+//      a missing folder or a folder without the backend library throws std::runtime_error
+//      so the caller surfaces a clear message instead of a late dlopen failure.
+//   2. GENIEX_PLUGIN_PATH env var — the bundled layout, libraries under `<path>/qairt/htp-files`
+//      (flattened to `<path>` on Android).
+//   3. Neither set — fall back to bare library names so the OS loader resolves them from its
+//      default search path (the default shipped behavior, unchanged).
 inline QnnRuntimeConfig make_qnn_runtime_config(const std::filesystem::path& model_dir) {
     namespace fs = std::filesystem;
 
     QnnRuntimeConfig runtime_cfg{};
 
-    fs::path backend_dir;
-#if defined(_WIN32)
-    // On Windows, use wide string API to properly handle Unicode paths
-    size_t required_size = 0;
-    _wgetenv_s(&required_size, nullptr, 0, L"GENIEX_PLUGIN_PATH");
-    if (required_size > 0) {
-        std::vector<wchar_t> env_buffer(required_size);
-        _wgetenv_s(&required_size, env_buffer.data(), required_size, L"GENIEX_PLUGIN_PATH");
-        if (env_buffer[0] != L'\0') {
-            backend_dir = std::filesystem::path(env_buffer.data());
+    // (1) Explicit override: GENIEX_QNN_LIB folder holds the QNN libs directly.
+    const fs::path qnn_lib_dir = read_env_path("GENIEX_QNN_LIB", L"GENIEX_QNN_LIB");
+    if (!qnn_lib_dir.empty()) {
+        std::error_code ec;
+        if (!fs::is_directory(qnn_lib_dir, ec)) {
+            throw std::runtime_error("GENIEX_QNN_LIB path is not a directory: " + qnn_lib_dir.string());
         }
+        const fs::path backend = qnn_lib_dir / kQnnBackendLib;
+        if (!fs::exists(backend, ec)) {
+            throw std::runtime_error(
+                "GENIEX_QNN_LIB does not contain " + std::string(kQnnBackendLib) + ": " + qnn_lib_dir.string());
+        }
+
+        GENIEX_LOG_INFO("Using custom QNN libraries from GENIEX_QNN_LIB: {}", qnn_lib_dir.string());
+        GENIEX_LOG_DEBUG("Setting ADSP_LIBRARY_PATH to {}", qnn_lib_dir.string());
+#if defined(WIN32)
+        _putenv_s("ADSP_LIBRARY_PATH", qnn_lib_dir.string().c_str());
+        SetDllDirectoryA(qnn_lib_dir.string().c_str());
+#else
+        setenv("ADSP_LIBRARY_PATH", qnn_lib_dir.string().c_str(), 1);
+#endif
+        runtime_cfg.backend_path    = backend.string();
+        runtime_cfg.system_lib_path = (qnn_lib_dir / kQnnSystemLib).string();
+        runtime_cfg.extensions_path = (qnn_lib_dir / kQnnExtensionsLib).string();
+
+        static_cast<void>(model_dir);  // reserved for future fallback logic
+        return runtime_cfg;
     }
-#else   // _WIN32
-    auto env_plugin_path = std::getenv("GENIEX_PLUGIN_PATH");
-    if (env_plugin_path) {
-        backend_dir = fs::path(env_plugin_path);
-    }
-#endif  // _WIN32
+
+    // (2) Bundled layout via GENIEX_PLUGIN_PATH, else (3) auto-detect (empty backend_dir).
+    fs::path backend_dir = read_env_path("GENIEX_PLUGIN_PATH", L"GENIEX_PLUGIN_PATH");
 
 #if not defined(__ANDROID__)  // android has flattened directory
     if (!backend_dir.empty()) {
@@ -85,15 +141,11 @@ inline QnnRuntimeConfig make_qnn_runtime_config(const std::filesystem::path& mod
     setenv("ADSP_LIBRARY_PATH", backend_dir.string().c_str(), 1);
 #endif
 
+    runtime_cfg.backend_path    = (backend_dir / kQnnBackendLib).string();
+    runtime_cfg.system_lib_path = (backend_dir / kQnnSystemLib).string();
+    runtime_cfg.extensions_path = (backend_dir / kQnnExtensionsLib).string();
 #ifdef _WIN32
-    runtime_cfg.backend_path    = (backend_dir / "QnnHtp.dll").string();
-    runtime_cfg.system_lib_path = (backend_dir / "QnnSystem.dll").string();
-    runtime_cfg.extensions_path = (backend_dir / "QnnHtpNetRunExtensions.dll").string();
     SetDllDirectoryA(backend_dir.string().c_str());
-#else  // __ANDROID__ and __linux__
-    runtime_cfg.backend_path    = (backend_dir / "libQnnHtp.so").string();
-    runtime_cfg.system_lib_path = (backend_dir / "libQnnSystem.so").string();
-    runtime_cfg.extensions_path = (backend_dir / "libQnnHtpNetRunExtensions.so").string();
 #endif
 
     static_cast<void>(model_dir);  // reserved for future fallback logic


### PR DESCRIPTION
## Summary

Adds the ability to point a single GenieX release at a different QAIRT/QNN library build at runtime, so users and internal testers can validate multiple QAIRT versions without rebuilding or reinstalling.

- **`GENIEX_QNN_LIB=<dir>`** — env var read by the qairt plugin. Points at a folder that directly contains the QNN shared libraries (`QnnHtp.dll` / `QnnSystem.dll` / `QnnHtpNetRunExtensions.dll`, or the `libQnn*.so` equivalents).
- **`--qnn-lib <dir>`** — CLI convenience flag that exports `GENIEX_QNN_LIB` for the process. The flag wins when both are set.
- **Default unchanged** — when neither is set, the plugin uses the bundled QNN-lib exactly as before.
- **Fails fast** — a missing directory or one lacking the backend library throws at model load with a clear message (e.g. `GENIEX_QNN_LIB does not contain QnnHtp.dll: <path>`), surfaced via the existing `geniex_llm_create` error path.

### Design notes

- No FFI/ABI change: `geniex.h` is untouched, so no binding FFI updates are required (CONTRIBUTING §4 N/A). Because the mechanism is an env var read inside the plugin, **all** front-ends (CLI, pybind, Android/JNI) pick it up for free.
- No submodule change: `QnnRuntimeConfig` in `third-party/geniex-qairt` already exposes `backend_path`/`system_lib_path`/`extensions_path` overrides. The change only populates them from a new source inside the SDK wrapper (`sdk/plugins/qairt`), which is main-repo code.
- Lib-name literals were de-duplicated into `kQnnBackendLib`/`kQnnSystemLib`/`kQnnExtensionsLib` constants shared by the override and bundled paths.

## Test plan

- [ ] Build the SDK bridge (`/build`) and CLI on a Snapdragon Windows host.
- [ ] `geniex infer local/granite4_micro --qnn-lib <alt-qnn-libs>` loads the alternate libraries (verify via `GENIEX_LOG=info` line "Using custom QNN libraries from GENIEX_QNN_LIB").
- [ ] `GENIEX_QNN_LIB=<alt-qnn-libs> geniex infer local/granite4_micro` behaves identically to the flag.
- [ ] A nonexistent path and a valid-but-empty folder each fail at load with the expected error message.
- [ ] No flag / no env var → still loads the bundled QNN-lib and produces correct output (default unchanged).
- [ ] Swap two different QAIRT/QNN versions against the same GenieX build and confirm each runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)