### PR TITLE
feat(cli): fetch updates from S3 index instead of GitHub releases

### DIFF
--- a/cli/cmd/geniex/main.go
+++ b/cli/cmd/geniex/main.go
@@ -55,7 +55,11 @@ func RootCmd() *cobra.Command {
 			}
 
 			if !skipUpdate {
-				notifyUpdate()
+				// `update` fetches and prints the latest version itself; the
+				// cached notify banner would be redundant and possibly stale.
+				if subCmd != "update" {
+					notifyUpdate()
+				}
 				// skip network probe for quick commands
 				if !slices.Contains([]string{
 					"geniex",

--- a/cli/cmd/geniex/update.go
+++ b/cli/cmd/geniex/update.go
@@ -6,7 +6,10 @@ package main
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"os"
@@ -27,8 +30,12 @@ import (
 )
 
 const (
-	githubAPIURL = "https://api.github.com/repos/qualcomm/GenieX/releases/latest"
-	userAgent    = "GenieX-Updater/1.0"
+	// releaseBaseURL is the S3 prefix holding index.json and the per-version
+	// manifest-<tag>.json files. manifest asset URLs are absolute, so this is
+	// only used to resolve index.json and manifest names.
+	releaseBaseURL = "https://qaihub-public-assets.s3.us-west-2.amazonaws.com/qai-hub-geniex/"
+	indexURL       = releaseBaseURL + "index.json"
+	userAgent      = "GenieX-Updater/1.0"
 
 	updateCheckInterval  = 24 * time.Hour
 	notificationInterval = 8 * time.Hour
@@ -36,7 +43,7 @@ const (
 	defaultChunkSize  = 4 * 1024 * 1024
 	defaultNumWorkers = 16
 
-	linuxInstallScriptURL = "https://qaihub-public-assets.s3.us-west-2.amazonaws.com/qai-hub-geniex/install.sh"
+	linuxInstallScriptURL = releaseBaseURL + "install.sh"
 )
 
 func update() *cobra.Command {
@@ -52,12 +59,17 @@ func update() *cobra.Command {
 }
 
 func runUpdate(_ *cobra.Command, _ []string) error {
-	rls, err := getLastRelease()
+	latest, err := getLatestVersion()
 	if err != nil {
 		return err
 	}
 
-	latest := rls.Name
+	// Refresh the cache so other commands' notify banner matches this result.
+	ck := getUpdateCheck()
+	ck.LastCheck = time.Now()
+	ck.LatestVersion = latest
+	setUpdateCheck(ck)
+
 	cmp, err := compareVersion(Version, latest)
 	if err != nil {
 		return err
@@ -80,16 +92,13 @@ func runUpdate(_ *cobra.Command, _ []string) error {
 		return fmt.Errorf("auto-update is not supported on %s/%s", runtime.GOOS, runtime.GOARCH)
 	}
 
-	assetName := fmt.Sprintf("geniex-cli-setup-windows-%s-%s.exe", runtime.GOARCH, latest)
-	var ast asset
-	for _, a := range rls.Assets {
-		if a.Name == assetName {
-			ast = a
-			break
-		}
+	mf, err := getManifest(latest)
+	if err != nil {
+		return err
 	}
-	if ast.Name == "" {
-		return fmt.Errorf("asset %s not found in release", assetName)
+	ast, err := mf.find("cli-installer", "windows", runtime.GOARCH)
+	if err != nil {
+		return err
 	}
 
 	fmt.Println(
@@ -114,6 +123,10 @@ func runUpdate(_ *cobra.Command, _ []string) error {
 		return dlErr
 	}
 
+	if err := verifySHA256(dst, ast.SHA256); err != nil {
+		return err
+	}
+
 	if err := exec.Command(dst).Start(); err != nil {
 		return err
 	}
@@ -121,58 +134,98 @@ func runUpdate(_ *cobra.Command, _ []string) error {
 	return nil
 }
 
-// GitHub release API
+// S3 release index & manifests
 
-// Release `name` is the display version (e.g. "v0.1.4"). We prefer it over
-// `tag_name` because releases published without a git tag surface a synthetic
-// `tag_name` like "untagged-<sha>".
-type release struct {
-	Name   string  `json:"name"`
+// index is the top-level S3 manifest listing every published version.
+type index struct {
+	LatestStable string `json:"latest_stable"`
+}
+
+// manifest describes the downloadable assets for one version.
+type manifest struct {
+	Tag    string  `json:"tag"`
 	Assets []asset `json:"assets"`
 }
 
 type asset struct {
-	// URL is the GitHub API endpoint. Use it (with Accept:
-	// application/octet-stream) for private repos — browser_download_url
-	// 404s when the release was published without a real git tag.
-	URL    string `json:"url"`
-	Name   string `json:"name"`
-	Size   int    `json:"size"`
-	Digest string `json:"digest"`
+	Name     string `json:"name"`
+	URL      string `json:"url"`
+	Size     int    `json:"size"`
+	SHA256   string `json:"sha256"`
+	Kind     string `json:"kind"`
+	Platform string `json:"platform"`
+	Arch     string `json:"arch"`
 }
 
-// resolveGitHubToken returns a PAT for authenticating the release-lookup call.
-// geniex's own var wins over the generic one used by gh / CI.
-func resolveGitHubToken() string {
-	if t := os.Getenv("GENIEX_GITHUB_TOKEN"); t != "" {
-		return t
+// find returns the asset matching kind/platform/arch, or an error if none.
+func (m manifest) find(kind, platform, arch string) (asset, error) {
+	for _, a := range m.Assets {
+		if a.Kind == kind && a.Platform == platform && a.Arch == arch {
+			return a, nil
+		}
 	}
-	return os.Getenv("GITHUB_TOKEN")
+	return asset{}, fmt.Errorf("no %s asset for %s/%s in release %s", kind, platform, arch, m.Tag)
 }
 
-func getLastRelease() (release, error) {
-	var rls release
-
-	req, err := http.NewRequest("GET", githubAPIURL, nil)
+// fetchJSON GETs url and decodes the JSON body into v.
+func fetchJSON(url string, v any) error {
+	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
-		return rls, err
+		return err
 	}
 	req.Header.Set("User-Agent", userAgent)
-	req.Header.Set("Accept", "application/vnd.github+json")
-	if tok := resolveGitHubToken(); tok != "" {
-		req.Header.Set("Authorization", "Bearer "+tok)
-	}
 
 	resp, err := (&http.Client{Timeout: 10 * time.Second}).Do(req)
 	if err != nil {
-		return rls, err
+		return err
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return rls, fmt.Errorf("get latest release failed: %d", resp.StatusCode)
+		return fmt.Errorf("get %s failed: %d", url, resp.StatusCode)
 	}
-	return rls, sonic.ConfigDefault.NewDecoder(resp.Body).Decode(&rls)
+	return sonic.ConfigDefault.NewDecoder(resp.Body).Decode(v)
+}
+
+// getLatestVersion returns the latest stable version tag from the S3 index.
+func getLatestVersion() (string, error) {
+	var idx index
+	if err := fetchJSON(indexURL, &idx); err != nil {
+		return "", err
+	}
+	if idx.LatestStable == "" {
+		return "", fmt.Errorf("no stable release found in index")
+	}
+	return idx.LatestStable, nil
+}
+
+// getManifest fetches the per-version asset manifest for tag.
+func getManifest(tag string) (manifest, error) {
+	var mf manifest
+	url := releaseBaseURL + "manifest-" + tag + ".json"
+	if err := fetchJSON(url, &mf); err != nil {
+		return mf, err
+	}
+	return mf, nil
+}
+
+// verifySHA256 checks that the file at path matches the expected hex digest.
+func verifySHA256(path, expected string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return err
+	}
+	got := hex.EncodeToString(h.Sum(nil))
+	if !strings.EqualFold(got, expected) {
+		return fmt.Errorf("checksum mismatch: expected %s, got %s", expected, got)
+	}
+	return nil
 }
 
 // compareVersion compares two SemVer strings.
@@ -213,8 +266,6 @@ func downloadPkg(url, dst string, size int64, progress chan int64) error {
 	g, ctx := errgroup.WithContext(context.Background())
 	g.SetLimit(numWorkers)
 	dl := downloader.NewDownloader()
-	dl.AuthToken = resolveGitHubToken()
-	dl.Headers = map[string]string{"Accept": "application/octet-stream"}
 
 	for offset := int64(0); offset < size; offset += chunkSize {
 		offset := offset
@@ -272,14 +323,14 @@ func checkUpdate() {
 		return
 	}
 
-	rls, err := getLastRelease()
+	latest, err := getLatestVersion()
 	if err != nil {
 		slog.Debug("update check failed", "error", err)
 		return
 	}
 
 	ck.LastCheck = time.Now()
-	ck.LatestVersion = rls.Name
+	ck.LatestVersion = latest
 	setUpdateCheck(ck)
 }
 


### PR DESCRIPTION
## What

`geniex update` now sources release info from the public S3 release index instead of the GitHub release API.

- `index.json` provides the latest stable version (`latest_stable`).
- `manifest-<tag>.json` lists the downloadable assets, each with a direct S3 URL, size, and sha256 digest.

## Why

The GitHub release API required a PAT (for private repos) and the octet-stream `Accept` workaround. The S3 bucket is public, so this drops all GitHub-only logic.

## Changes

- Replace `getLastRelease` (GitHub API) with `getLatestVersion` (index.json) + `getManifest` (per-tag manifest).
- Drop PAT resolution (`GENIEX_GITHUB_TOKEN`/`GITHUB_TOKEN`) and the octet-stream header from the downloader.
- Select assets by `kind`/`platform`/`arch` instead of matching a constructed filename.
- **Verify the downloaded installer's sha256** before executing it (manifest supplies the digest; previously there was no verification).
- Fix a version-display inconsistency: `geniex update` now refreshes the update-check cache and skips the notify banner, so the version it prints and the banner other commands show can no longer diverge.

## Testing

- `bazelisk build //cli:cli` passes.
- Ran `geniex update` on Linux: correctly reads `latest_stable` from S3 and prints the install-script upgrade path; confirmed the cache/banner now match.