### PR TITLE
ci(build-sdk): build unsigned HTP skels when signing secret is absent

### DIFF
--- a/.github/workflows/_build-sdk.yml
+++ b/.github/workflows/_build-sdk.yml
@@ -185,7 +185,8 @@ jobs:
         run: |
           $ErrorActionPreference = "Stop"
           if (-not $env:HEXAGON_HTP_CERT_PFX) {
-            throw "HEXAGON_HTP_CERT_PFX secret is empty; set it to the base64 of the HTP .pfx."
+            Write-Warning "HEXAGON_HTP_CERT_PFX secret is unavailable (expected on fork PRs); building unsigned HTP skels."
+            exit 0
           }
           $dst = "$env:RUNNER_TEMP\ggml-htp-v1.pfx"
           [IO.File]::WriteAllBytes($dst, [Convert]::FromBase64String($env:HEXAGON_HTP_CERT_PFX))


### PR DESCRIPTION
## Summary

Fork PRs (e.g. #1165) fail `build-sdk / windows-arm64` because a public repo never passes secrets to a fork's `pull_request` workflow, so `HEXAGON_HTP_CERT_PFX` is empty and the `Configure HTP signing cert` step `throw`s before CMake runs.

The signing that secret drives is a runtime, on-device concern, not a build dependency: the sign/`.cat` block in llama.cpp's `ggml-hexagon/CMakeLists.txt` is already gated `if (Windows AND GGML_HEXAGON_HTP_CERT)`, the skels install unconditionally, and the SDK-side `.cat` install is `OPTIONAL`. So with no cert the build simply completes unsigned.

This softens the step: when the secret is empty, warn and skip writing `HEXAGON_HTP_CERT` instead of throwing. The Windows build then produces unsigned HTP skels and passes. When the secret is present (main-repo branches, release), nothing in `$GITHUB_ENV` changes and the signed path is byte-for-byte unchanged. Release CI's `overlay-htp` job still guarantees signing at ship time.

`build-llama-cpp-windows.yml` has an identical `throw`; left unchanged here since it is a standalone llama.cpp-only workflow, not on the PR Check path.

## Test plan

- [x] main-repo CI (secret present): `build-sdk / windows-arm64` green -> signed path unbroken (run 29242239937; cert step logged `HEXAGON_HTP_CERT=...`, not the warning)