### PR TITLE
fix(cli): align serve short aliases with infer/run

### DIFF
--- a/cli/cmd/geniex/serve.go
+++ b/cli/cmd/geniex/serve.go
@@ -30,8 +30,8 @@ func serve() *cobra.Command {
 	// Model-load defaults applied when a request omits them (llama_cpp only;
 	// per-request body fields still override).
 	serveCmd.Flags().Int32("nctx", 4096, "Default context window size, llama_cpp only (env: GENIEX_NCTX)")
-	serveCmd.Flags().Int32("ngl", 999, "Default layers to offload to gpu/npu, llama_cpp only (env: GENIEX_NGL)")
-	serveCmd.Flags().String("compute", "", "Default compute unit: cpu, gpu, npu, or hybrid (env: GENIEX_COMPUTE)")
+	serveCmd.Flags().Int32P("ngl", "n", 999, "Default layers to offload to gpu/npu, llama_cpp only (env: GENIEX_NGL)")
+	serveCmd.Flags().StringP("compute", "c", "", "Default compute unit: cpu, gpu, npu, or hybrid (env: GENIEX_COMPUTE)")
 	// HTTPS / TLS flags
 	serveCmd.Flags().Bool("https", false, "Enable HTTPS/TLS (env: GENIEX_HTTPS)")
 	serveCmd.Flags().String("certfile", "cert.pem", "TLS certificate file path (env: GENIEX_CERTFILE)")


### PR DESCRIPTION
## What

Add short aliases to `serve` for the two flags it shares with `infer`/`run`:

- `--compute` → `-c`
- `--ngl` → `-n`

## Why

`serve` defined these flags without short aliases, while `infer` and `run` (via the shared `llmFlags` set in `infer.go`) already expose `-c`/`-n`. This aligns `serve` with the rest of the CLI. Other serve-only flags are left untouched.