### PR TITLE
ci(build-sdk): override cached HTP cert path so unsigned fork builds skip signing

### DIFF
--- a/.github/workflows/_build-sdk.yml
+++ b/.github/workflows/_build-sdk.yml
@@ -258,8 +258,13 @@ jobs:
           }
           $env:PATH = "$env:LLVM_BIN;$env:PATH"
 
+          # Pass the cert path explicitly: GGML_HEXAGON_HTP_CERT is a cached
+          # PATH, so a restored build dir keeps a prior run's value and an
+          # empty env alone won't clear it — on a fork PR (no secret) that
+          # leaves signing on and signtool fails on the missing .pfx.
           cmake -S sdk --preset $env:PRESET -B $BuildDir --log-level=VERBOSE `
             "-DGENIEX_VERSION=$env:GENIEX_VERSION" `
+            "-DGGML_HEXAGON_HTP_CERT=$env:HEXAGON_HTP_CERT" `
             -DCMAKE_C_COMPILER_LAUNCHER=ccache `
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
           if ($LASTEXITCODE -ne 0) { throw "cmake configure failed: $LASTEXITCODE" }


### PR DESCRIPTION
## Summary

Follow-up to #1171. That PR stopped the HTP-cert step from `throw`ing when the
signing secret is absent, but `build-sdk / windows-arm64` still failed on the
rebased #1165 with:

```
SignTool Error: File not found: C:/a/_temp/ggml-htp-v1.pfx
```

Root cause: the windows job restores the whole CMake build dir via `actions/cache`
(the `restore-keys` fall back across commits). `GGML_HEXAGON_HTP_CERT` is a cached
`PATH` variable, so a restored `CMakeCache.txt` from an earlier **signed** run keeps
its old `.pfx` path — an empty env alone doesn't clear it. CMake therefore re-enters
llama.cpp's signing branch (`ggml-hexagon/CMakeLists.txt` gates on that var) and
`signtool` fails on the `.pfx` this fork run never wrote.

Fix: pass `-DGGML_HEXAGON_HTP_CERT="$env:HEXAGON_HTP_CERT"` at configure time so the
cached value is forced to match the current env every run — the real path when the
secret is present (signed path unchanged), empty on a fork PR (signing skipped,
unsigned build).

Verified locally with a minimal project mirroring the `set(... CACHE PATH)` + gate:
a restored cache keeps signing on with an empty env, and the `-D` override flips it
to the unsigned path (and back to signed when a real path is passed).

## Test plan

- [x] local CMake repro: `-D` override clears a cached cert path -> gate takes unsigned branch; real path -> signed branch