### PR TITLE
docs(docs): expand contributing guide for open-source contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,72 +1,63 @@
 # Contributing to geniex
 
-Rules contributors — human and AI — follow when committing, branching, and opening pull requests.
+Thanks for your interest in contributing! Whether you're fixing a typo, adding a backend, or landing a new feature, this guide takes you from `git clone` to a merged PR. The same rules apply to external and internal contributors — this is the single source of truth.
 
-The rules are **SemVer-driven**: commit messages and PR titles must encode enough information for [`/release`](.claude/commands/release.md) (and future automation) to derive the next version tag deterministically. The full tag procedure lives in [notes/release.md](notes/release.md).
+The commit and PR rules are **SemVer-driven**: they must encode enough information for [`/release`](.claude/commands/release.md) (and future automation) to derive the next version tag deterministically. The full tag procedure lives in [notes/release.md](notes/release.md).
 
-## 1. Commits — Conventional Commits
+## Getting started
 
-```
-<type>(<scope>)[!]: <subject>
+Prerequisites:
 
-<body>            # optional; only when the "why" is non-obvious
-<footer>          # optional; BREAKING CHANGE, issue refs
-```
+- **[Bazelisk](https://github.com/bazelbuild/bazelisk)** — builds the Go CLI and fetches all CLI-side dependencies. The Bazel version is pinned in [.bazelversion](.bazelversion). Install: `winget install --id Bazel.Bazelisk` (Windows) or `bazelisk` from your package manager (Linux).
+- **CMake** — builds the SDK bridge and native plugins via presets in [sdk/CMakePresets.json](sdk/CMakePresets.json).
+- **Docker** — the Linux and Android SDK builds run inside prebuilt toolchain images (`qualcomm/geniex-toolchain-linux`, `qualcomm/geniex-toolchain-android`). A full Windows Snapdragon build additionally needs the Hexagon SDK, OpenCL SDK, and Windows Driver Kit.
 
-### Types
+Clone with submodules — the SDK vendors `third-party/llama.cpp` and `third-party/geniex-qairt`:
 
-Every commit MUST use one of these. CI and `/release` derive the SemVer bump from the type.
-
-| Type       | Meaning                                      | Bump               |
-|------------|----------------------------------------------|--------------------|
-| `feat`     | New user-visible feature.                    | MINOR              |
-| `fix`      | Bug fix.                                     | PATCH              |
-| `perf`     | Performance improvement, no behavior change. | PATCH              |
-| `refactor` | Internal restructure, no behavior change.    | PATCH              |
-| `docs`     | Documentation only.                          | PATCH              |
-| `chore`    | Build, deps, tooling, misc.                  | PATCH              |
-| `test`     | Test-only change.                            | PATCH              |
-| `ci`       | CI config only.                              | PATCH              |
-| `revert`   | Revert a prior commit.                       | no bump by default |
-
-### Breaking changes
-
-Mark with `!` after the type/scope, or with a `BREAKING CHANGE:` footer:
-
-```
-feat(cli)!: rename --model flag to --model-id
+```bash
+git clone --recursive https://github.com/qualcomm/GenieX.git
 ```
 
-```
-feat(sdk): restructure plugin loader
+> [!IMPORTANT]
+> **Build the SDK before the CLI.** In the default local-SDK mode the CLI links against `sdk/pkg-geniex/`, which must already exist. Full per-platform build commands (Windows ARM64, Linux, Android) live in [notes/build.md](notes/build.md); Python bindings in [bindings/python/README.md](bindings/python/README.md).
 
-BREAKING CHANGE: plugins must now expose geniex_plugin_v2_init.
-```
+## Running tests
 
-**Pre-1.0 rule.** The repo is private and pre-1.0 — the leading `X` in `vX.Y.Z` **must stay `0`** until the first public release. Breaking changes bump **MINOR**, not MAJOR, while `X = 0`.
+- **Go / CLI** — run via coverage rather than plain `test` (every package ships a placeholder test to stay in the coverage denominator):
 
-### Scope
+  ```bash
+  bazelisk coverage //... --combined_report=lcov
+  ```
 
-One scope per commit, naming the area touched. Current scopes: `cli`, `sdk`, `python`, `android`, `go`, `server`, `build`, `release`, `ci`, `dx`, `docs`. Introduce a new scope in the same PR that introduces the area.
+  The [`coverage`](.claude/skills/coverage/SKILL.md) skill wraps this and renders HTML.
 
-### Subject
+- **SDK / plugins (Python)** — end-to-end pytest suite driven through the public binding. Model-free checks run anywhere; model and device cells need Snapdragon hardware (see [tests/README.md](tests/README.md)):
 
-- Imperative mood (`add`, not `added` / `adds`).
-- ≤ 72 characters.
-- No trailing period.
-- Describe *what*, not *why* — the body is for *why*.
+  ```bash
+  pytest tests -m api                                  # model-free, runs anywhere
+  pytest tests -m "api or (llama_cpp and device_cpu)"  # adds llama_cpp CPU cells
+  GENIEX_DEVICE_TEST=1 pytest tests                    # full matrix, Snapdragon only
+  ```
 
-**Banned subjects** — reviewers and agents must reject these; they make version derivation impossible: `update code`, `fix bug`, `misc`, `wip`, `tmp`, empty, placeholder, non-ASCII.
+CI runs only the model-free shard on GitHub runners; the device matrix runs on real QDC hardware via [pr-check.yml](.github/workflows/pr-check.yml).
 
-### Body
+## Project structure
 
-Omit by default. Add only when the "why" is non-obvious: a hidden constraint, a subtle invariant, or a decision a future reader will question. Do not restate the diff. No co-authors, no emojis, no trailing summary lines.
+| Directory        | Contents                                                                       |
+|------------------|--------------------------------------------------------------------------------|
+| [sdk/](sdk/)     | Native C-ABI core (`include/geniex.h`), backend plugins (`llama_cpp`, `qairt`), Rust model-manager, benchmark. |
+| [cli/](cli/)     | Go CLI (`cmd/`, `internal/`, `server/`, `release/`), built with Bazel.         |
+| [bindings/](bindings/) | Language bindings: `android/`, `go/`, `python/`, `python-llama-cpp/`, `python-qairt/`. |
+| [docs/](docs/)   | Documentation site (Mintlify).                                                 |
+| [examples/](examples/) | Sample usage (`android/`, `python/`).                                    |
+| [tests/](tests/) | SDK/plugin pytest suite + Go CLI black-box tests + QDC device harness.          |
+| [scripts/](scripts/)   | Bazel helper rules.                                                      |
+| [third-party/](third-party/) | Vendored `llama.cpp` and `geniex-qairt` submodules.               |
+| [notes/](notes/) | Developer playbooks (build, run, release, bench, AI).                           |
 
-### Shaping history
+## Making a change
 
-If local history is messy before opening a PR, prefer the [`reshape-pr-commits`](.claude/skills/reshape-pr-commits/SKILL.md) skill. Without Claude Code, use `git rebase -i` to squash/fixup/reword the equivalent commits manually.
-
-## 2. Branches
+### Branches
 
 Format: `<type>/<short-topic>`. Base branch is `main`.
 
@@ -80,62 +71,103 @@ Format: `<type>/<short-topic>`. Base branch is `main`.
 | `ci`      | CI config only.                            | `ci/add-windows-runner`     |
 | `release` | Long-lived release-prep branches (rare).   | `release/0.5`               |
 
-Tag policy (which channels may be cut from which branches) lives in [notes/release.md](notes/release.md).
+Personal dev branches like `perry/dev/<topic>` are allowed for shared WIP. Tag policy (which channels may be cut from which branches) lives in [notes/release.md](notes/release.md).
 
-### Personal dev branches
+### Commits — Conventional Commits
 
-Personal branches like `perry/dev/<topic>` or `paul/dev/<topic>` are allowed for shared WIP and may be merged directly.
+```
+<type>(<scope>)[!]: <subject>
 
-Agents opening a PR from a personal branch MUST warn the user once that the branch name does not follow the typed convention, and proceed only after explicit confirmation. The PR title still must follow the commit format in § 1.
+<body>            # optional; only when the "why" is non-obvious
+<footer>          # optional; BREAKING CHANGE, issue refs, Signed-off-by
+```
 
-## 3. Before you commit
+Every commit MUST use one of these types. CI and `/release` derive the SemVer bump from the type.
 
-Run the same checks CI runs — the authoritative list is [.github/workflows/lint.yml](.github/workflows/lint.yml). As of today:
+| Type       | Meaning                                      | Bump               |
+|------------|----------------------------------------------|--------------------|
+| `feat`     | New user-visible feature.                    | MINOR              |
+| `fix`      | Bug fix.                                     | PATCH              |
+| `perf`     | Performance improvement, no behavior change. | PATCH              |
+| `refactor` | Internal restructure, no behavior change.    | PATCH              |
+| `docs`     | Documentation only.                          | PATCH              |
+| `chore`    | Build, deps, tooling, misc.                  | PATCH              |
+| `test`     | Test-only change.                            | PATCH              |
+| `ci`       | CI config only.                              | PATCH              |
+| `revert`   | Revert a prior commit.                       | no bump by default |
 
-- **C/C++**: `clang-format` on touched files under `sdk/`, `cli/`, `bindings/python/`.
-- **Python**: `ruff check` + `ruff format --check` on `bindings/python/**/*.py`.
-- **Go**: `go mod tidy` clean inside `cli/`.
+- **Scope** — one per commit, naming the area touched: `cli`, `sdk`, `python`, `android`, `go`, `server`, `build`, `release`, `ci`, `dx`, `docs`. Introduce a new scope in the same PR that introduces the area.
+- **Subject** — imperative mood (`add`, not `added`), ≤ 72 characters, no trailing period, describes *what* not *why*. Banned subjects (reviewers reject them — they make version derivation impossible): `update code`, `fix bug`, `misc`, `wip`, `tmp`, empty, placeholder, non-ASCII.
+- **Body** — omit by default; add only when the "why" is non-obvious. Don't restate the diff. No co-authors, no emojis.
+- **Breaking changes** — mark with `!` after the type/scope (`feat(cli)!: rename --model flag`) or a `BREAKING CHANGE:` footer. **Pre-1.0 rule:** the leading `X` in `vX.Y.Z` stays `0` until the first stable public release, so breaking changes bump **MINOR**, not MAJOR, while `X = 0`.
+
+If local history is messy before opening a PR, tidy it with the [`reshape-pr-commits`](.claude/skills/reshape-pr-commits/SKILL.md) skill or `git rebase -i`.
+
+### Sign your commits (DCO)
+
+This project uses the [Developer Certificate of Origin](https://developercertificate.org/). Every commit must carry a `Signed-off-by` line — add it with `-s`:
+
+```bash
+git commit -s -m "fix(sdk): guard null plugin handle"
+```
+
+The DCO check in CI rejects PRs whose commits are not signed off.
+
+Keep each change focused — split independent changes into separate PRs.
+
+## Code style & linting
+
+Run the same checks CI runs before you commit. The authoritative list is [.github/workflows/_lint.yml](.github/workflows/_lint.yml); as of today:
+
+| Language | Scope                                              | Command                                          |
+|----------|----------------------------------------------------|--------------------------------------------------|
+| C/C++    | touched files under `sdk/`, `cli/`, `bindings/python/` | `clang-format-18 -i <file>`                  |
+| Python   | `bindings/python/**/*.py`                          | `ruff check --fix <file> && ruff format <file>`  |
+| Go       | `cli/`                                             | `go mod tidy` (commit the `go.mod`/`go.sum` diff) |
 
 When CI adds a check, this section needs no edit — the workflow is the source of truth.
 
-Tests: see the section of [notes/build.md](notes/build.md) matching your target.
+### Changing public SDK headers
 
-## 4. Changing public SDK headers
+Public headers live under [sdk/include/](sdk/include/). Changing them requires updating every binding's FFI surface **in the same PR** — otherwise the binding crashes at load or first call.
 
-Public headers live under [sdk/include/](sdk/include/). Changing them requires updating every binding's FFI surface **in the same commit / PR** — otherwise the binding crashes at load or first call.
-
-| Binding        | FFI surface                                                                                                                 |
-|----------------|-----------------------------------------------------------------------------------------------------------------------------|
+| Binding        | FFI surface                                                                                                                    |
+|----------------|-------------------------------------------------------------------------------------------------------------------------------|
 | Python ctypes  | [bindings/python/geniex/_ffi/_api.py](bindings/python/geniex/_ffi/_api.py), [_types.py](bindings/python/geniex/_ffi/_types.py) |
-| Go cgo         | [bindings/go/](bindings/go/)                                                                                                |
-| Android JNI    | [bindings/android/app/src/main/cpp/](bindings/android/app/src/main/cpp/)                                                    |
-
-After updating one binding, ask whether the others need to move too.
+| Go cgo         | [bindings/go/](bindings/go/)                                                                                                   |
+| Android JNI    | [bindings/android/app/src/main/cpp/](bindings/android/app/src/main/cpp/)                                                       |
 
 ### Logging
 
-New code MUST route log output through the existing channels — no raw
-`std::cerr`, `printf`, Go `log` / `fmt.Println`, Python `print`, or direct
-`android.util.Log` calls inside library code paths.
+Library code MUST route log output through the existing channels — no raw `std::cerr`, `printf`, Go `log`/`fmt.Println`, Python `print`, or direct `android.util.Log`.
 
-| Area             | Use                                                |
-|------------------|----------------------------------------------------|
-| SDK C/C++        | `GENIEX_LOG_TRACE/DEBUG/INFO/WARN/ERROR` macros    |
-| Go (CLI+binding) | `log/slog`                                         |
-| Python           | `logging.getLogger("geniex")` (or a child logger)  |
+| Area             | Use                                                          |
+|------------------|--------------------------------------------------------------|
+| SDK C/C++        | `GENIEX_LOG_TRACE/DEBUG/INFO/WARN/ERROR` macros              |
+| Go (CLI+binding) | `log/slog`                                                   |
+| Python           | `logging.getLogger("geniex")` (or a child logger)            |
 | Android / JNI    | `android.util.Log` in Kotlin; JNI forwards through `geniex_set_log` |
 
-The user-facing control is `GENIEX_LOG` (`trace`/`debug`/`info`/`warn`/`error`/`none`),
-read by each binding's logger. Filtering happens on the binding side — the SDK
-forwards every log line to the registered callback.
+The user-facing control is `GENIEX_LOG` (`trace`/`debug`/`info`/`warn`/`error`/`none`), read by each binding's logger.
 
-## 5. Opening a PR
+## Opening a PR
 
-- **Base**: `main`.
-- **Merge strategy**: Rebase. **The PR title MUST follow the Conventional Commits format** in § 1. Reviewers and agents reject titles that do not.
-- **Body**: follow the shape seen in recent merged PRs — `## Summary`, optional subsections for large changes, `## Test plan` as a checklist, and a `Closes #<issue>` line.
-- **Reviewers**: no required reviewers today; request review from the owner of the area you touched.
+- **Base**: `main`. **Merge strategy**: rebase.
+- **Title**: MUST follow the Conventional Commits format above — reviewers and agents reject titles that don't.
+- **Body**: `## Summary`, a `## Test plan` checklist, and a `Closes #<issue>` line. Follow the shape of recent merged PRs.
+- **Checks**: the PR graph ([pr-check.yml](.github/workflows/pr-check.yml)) runs lint → build-sdk → CLI/Python/Android builds → docker. In parallel, [qcom-preflight-checks.yml](.github/workflows/qcom-preflight-checks.yml) runs Semgrep, DCO sign-off, copyright/license, commit-email, and dependency review. Resolve anything they flag before merge.
+- **Reviewers**: no required reviewers today; request review from the owner of the area you touched — see [CODEOWNERS](CODEOWNERS).
 
-## 6. Releases
+## Reporting issues
 
-See [notes/release.md](notes/release.md). The [`/release`](.claude/commands/release.md) slash command walks through the tag format, channel semantics (`alpha` / `beta` / `rc` / stable), and decision procedure.
+Open an issue at [github.com/qualcomm/GenieX/issues](https://github.com/qualcomm/GenieX/issues). A good bug report includes a minimal repro, your environment (OS, device, backend, model), and relevant logs (`GENIEX_LOG=debug`). Feature requests are welcome as issues too — describe the use case, not just the implementation.
+
+For **security vulnerabilities**, do **not** open a public issue — follow [SECURITY.md](SECURITY.md).
+
+## Community & Code of Conduct
+
+Participation is governed by our [Code of Conduct](CODE-OF-CONDUCT.md). Be respectful and constructive.
+
+## Releases
+
+See [notes/release.md](notes/release.md). The [`/release`](.claude/commands/release.md) command walks through the tag format, channel semantics (`alpha`/`beta`/`rc`/stable), and decision procedure.


### PR DESCRIPTION
## Summary

Rewrites `CONTRIBUTING.md` into a complete, welcoming guide for the open-source launch — a contributor can now go from `git clone` to a merged PR without extra hand-holding. Part of the open-source-docs work tracked in qcom-ai-hub/geniex#1225 (parent epic: Open Source GitHub).

**Added** sections that were missing:
- **Getting started** — prerequisites (Bazelisk, CMake, Docker toolchain images), `git clone --recursive`, build-SDK-before-CLI order (links `notes/build.md`).
- **Running tests** — Go/CLI via `bazelisk coverage`, SDK/Python pytest markers (links `tests/README.md`).
- **Project structure** — table mapping the top-level directories.
- **DCO sign-off** — `git commit -s`, which CI already enforces but the guide never documented.
- **Code style & linting** — promoted to its own section with per-language commands.
- **Reporting issues** and **Community & Code of Conduct**.

**Preserved** the existing high-value rules: Conventional Commits tables, branch conventions, the public-SDK-header FFI-update rule, logging channels, and the SemVer/release pointer.

This is the first of three PRs; `geniex-proc` and `geniex-qairt-plugin` get the same structure as follow-ups so all three guides read consistently.

## Test plan

- [x] Every relative link in the new guide resolves to an existing path in the repo (29/29 checked).