### PR TITLE
fix(sdk): fail cleanly on CPUs missing required armv8.2 features

### DIFF
--- a/bindings/go/ml.go
+++ b/bindings/go/ml.go
@@ -56,8 +56,12 @@ var (
 )
 
 // Init must be called before any other SDK function.
-func Init() {
-	C.geniex_init()
+func Init() error {
+	res := C.geniex_init()
+	if res < 0 {
+		return SDKError(res)
+	}
+	return nil
 }
 
 func DeInit() {

--- a/cli/cmd/geniex/common/BUILD.bazel
+++ b/cli/cmd/geniex/common/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "log.go",
         "process.go",
         "repl.go",
+        "sdk.go",
         "util_linux.go",
         "util_windows.go",
     ],
@@ -39,6 +40,9 @@ go_library(
 
 go_cgo_test(
     name = "common_test",
-    srcs = ["process_test.go"],
+    srcs = [
+        "error_test.go",
+        "process_test.go",
+    ],
     embed = [":common"],
 )

--- a/cli/cmd/geniex/common/error.go
+++ b/cli/cmd/geniex/common/error.go
@@ -90,6 +90,12 @@ Possible causes: network timeout, corporate proxy, or firewall.
 - Run 'geniex list' to see what's been downloaded for this model.
 - Run 'geniex pull <model>:<precision>' to download it.
 - Drop the ':<precision>' suffix to be prompted from what's already downloaded.`
+
+	hintCPUUnsupported = `⚠️ This device is missing CPU features that geniex requires, so it cannot run here.
+
+👉 Try these:
+- Run geniex on a newer device that meets the CPU requirements.
+- If you believe this device should be supported, report it in our discord or slack with the output of 'uname -m' and 'cat /proc/cpuinfo'.`
 )
 
 // CLI-side sentinels. SDK sentinels live in bindings/go. Producers wrap with
@@ -101,6 +107,11 @@ var (
 	// ErrPrecisionNotFound: the user-specified precision is missing from
 	// the model's local manifest (or listed but not downloaded).
 	ErrPrecisionNotFound = errors.New("precision not found")
+	// ErrCPUUnsupported: geniex_init reported the CPU lacks a required
+	// feature. The SDK returns the generic NOT_SUPPORTED code for this, so
+	// callers wrap it here to get a CPU-specific hint distinct from the
+	// unsupported-model-type case.
+	ErrCPUUnsupported = errors.New("cpu feature unsupported")
 )
 
 var errorHints = []struct {
@@ -120,6 +131,7 @@ var errorHints = []struct {
 	{geniex_sdk.ErrCommonNetwork, hintHubUnreachable},
 	{ErrServerUnreachable, hintServerUnreachable},
 	{ErrPrecisionNotFound, hintPrecisionNotFound},
+	{ErrCPUUnsupported, hintCPUUnsupported},
 }
 
 // PrintError renders err for the user on stderr in the theme's error style

--- a/cli/cmd/geniex/common/error_test.go
+++ b/cli/cmd/geniex/common/error_test.go
@@ -1,0 +1,39 @@
+// Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
+package common
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	geniex_sdk "github.com/qualcomm/GenieX/bindings/go"
+)
+
+// hintFor returns the hint errorHints would render for err, or "" if none match.
+// Mirrors PrintError's first-match-wins loop.
+func hintFor(err error) string {
+	for _, h := range errorHints {
+		if errors.Is(err, h.sentinel) {
+			return h.hint
+		}
+	}
+	return ""
+}
+
+// The SDK returns the same NOT_SUPPORTED code for an unsupported model type and
+// for a CPU-feature failure at init. InitSDK wraps the init case so it resolves
+// to the CPU hint, not the model-type hint, even though the CPU sentinel is
+// listed after it in errorHints.
+func TestCPUUnsupportedHintWins(t *testing.T) {
+	wrapped := fmt.Errorf("%w: %v", ErrCPUUnsupported, geniex_sdk.ErrCommonNotSupport)
+
+	if got := hintFor(wrapped); got != hintCPUUnsupported {
+		t.Fatalf("wrapped init error resolved to wrong hint:\n%s", got)
+	}
+	// A bare NOT_SUPPORTED (e.g. unsupported model type) must still get its own hint.
+	if got := hintFor(geniex_sdk.ErrCommonNotSupport); got != hintNotSupport {
+		t.Fatalf("bare NOT_SUPPORTED resolved to wrong hint:\n%s", got)
+	}
+}

--- a/cli/cmd/geniex/common/error_test.go
+++ b/cli/cmd/geniex/common/error_test.go
@@ -5,7 +5,6 @@ package common
 
 import (
 	"errors"
-	"fmt"
 	"testing"
 
 	geniex_sdk "github.com/qualcomm/GenieX/bindings/go"
@@ -23,14 +22,12 @@ func hintFor(err error) string {
 }
 
 // The SDK returns the same NOT_SUPPORTED code for an unsupported model type and
-// for a CPU-feature failure at init. InitSDK wraps the init case so it resolves
-// to the CPU hint, not the model-type hint, even though the CPU sentinel is
-// listed after it in errorHints.
+// for a CPU-feature failure at init. InitSDK maps the init case to
+// ErrCPUUnsupported so it resolves to the CPU hint, not the model-type hint, even
+// though ErrCommonNotSupport is listed before it in errorHints.
 func TestCPUUnsupportedHintWins(t *testing.T) {
-	wrapped := fmt.Errorf("%w: %v", ErrCPUUnsupported, geniex_sdk.ErrCommonNotSupport)
-
-	if got := hintFor(wrapped); got != hintCPUUnsupported {
-		t.Fatalf("wrapped init error resolved to wrong hint:\n%s", got)
+	if got := hintFor(ErrCPUUnsupported); got != hintCPUUnsupported {
+		t.Fatalf("ErrCPUUnsupported resolved to wrong hint:\n%s", got)
 	}
 	// A bare NOT_SUPPORTED (e.g. unsupported model type) must still get its own hint.
 	if got := hintFor(geniex_sdk.ErrCommonNotSupport); got != hintNotSupport {

--- a/cli/cmd/geniex/common/sdk.go
+++ b/cli/cmd/geniex/common/sdk.go
@@ -1,0 +1,26 @@
+// Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
+package common
+
+import (
+	"errors"
+	"fmt"
+
+	geniex_sdk "github.com/qualcomm/GenieX/bindings/go"
+)
+
+// InitSDK calls the SDK init and maps its generic NOT_SUPPORTED result to the
+// CPU-specific sentinel so callers surface hintCPUUnsupported. Other init
+// failures are returned unchanged.
+func InitSDK() error {
+	err := geniex_sdk.Init()
+	if errors.Is(err, geniex_sdk.ErrCommonNotSupport) {
+		// Wrap with %v, not %w: the SDK returns the generic NOT_SUPPORTED code
+		// for both this and the unsupported-model-type case, so keeping it in
+		// the Is-chain would match hintNotSupport first. ErrCPUUnsupported is
+		// the only sentinel we want PrintError to see here.
+		return fmt.Errorf("%w: %v", ErrCPUUnsupported, err)
+	}
+	return err
+}

--- a/cli/cmd/geniex/common/sdk.go
+++ b/cli/cmd/geniex/common/sdk.go
@@ -5,7 +5,6 @@ package common
 
 import (
 	"errors"
-	"fmt"
 
 	geniex_sdk "github.com/qualcomm/GenieX/bindings/go"
 )
@@ -16,11 +15,10 @@ import (
 func InitSDK() error {
 	err := geniex_sdk.Init()
 	if errors.Is(err, geniex_sdk.ErrCommonNotSupport) {
-		// Wrap with %v, not %w: the SDK returns the generic NOT_SUPPORTED code
-		// for both this and the unsupported-model-type case, so keeping it in
-		// the Is-chain would match hintNotSupport first. ErrCPUUnsupported is
-		// the only sentinel we want PrintError to see here.
-		return fmt.Errorf("%w: %v", ErrCPUUnsupported, err)
+		// Return ErrCPUUnsupported alone, not wrapping the SDK error: the SDK
+		// uses the same NOT_SUPPORTED code for the unsupported-model-type case,
+		// so keeping it in the Is-chain would match hintNotSupport first.
+		return ErrCPUUnsupported
 	}
 	return err
 }

--- a/cli/cmd/geniex/infer.go
+++ b/cli/cmd/geniex/infer.go
@@ -124,7 +124,9 @@ func infer() *cobra.Command {
 			return err
 		}
 
-		geniex_sdk.Init()
+		if err := common.InitSDK(); err != nil {
+			return err
+		}
 
 		switch paths.ModelType {
 		case geniex_sdk.ModelTypeLLM:

--- a/cli/cmd/geniex/serve.go
+++ b/cli/cmd/geniex/serve.go
@@ -4,10 +4,13 @@
 package main
 
 import (
+	"os"
+
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
 	geniex_sdk "github.com/qualcomm/GenieX/bindings/go"
+	"github.com/qualcomm/GenieX/cli/cmd/geniex/common"
 	"github.com/qualcomm/GenieX/cli/server"
 )
 
@@ -49,7 +52,10 @@ func serve() *cobra.Command {
 
 	serveCmd.Run = func(cmd *cobra.Command, args []string) {
 		checkAudioDependency()
-		geniex_sdk.Init()
+		if err := common.InitSDK(); err != nil {
+			common.PrintError(err)
+			os.Exit(1)
+		}
 
 		server.Serve()
 

--- a/cli/cmd/geniex/version.go
+++ b/cli/cmd/geniex/version.go
@@ -88,7 +88,10 @@ func resolvePluginVersions() map[string]string {
 		return cached
 	}
 
-	geniex_sdk.Init()
+	if err := geniex_sdk.Init(); err != nil {
+		// Best-effort path: without init we just report no plugin versions.
+		return nil
+	}
 	defer geniex_sdk.DeInit()
 
 	versions := make(map[string]string, len(pluginIDs))

--- a/docs/cn/resources/troubleshooting.mdx
+++ b/docs/cn/resources/troubleshooting.mdx
@@ -79,6 +79,19 @@ import Feedback from "/snippets/page-feedback.mdx";
   <Accordion title="容器内可加载模型但推理报 `Failed to create device: 14001`">
     容器无法访问 NPU。确认 `docker run` 带 `--privileged` 与 `/usr/lib` 挂载，并且主机已安装高通驱动包（`qcom-adreno1`、`qcom-fastrpc1`）——参见 [Linux 安装 → 安装宿主机依赖](/cn/run/linux/install#安装宿主机依赖)。
   </Accordion>
+
+  <Accordion title="`geniex` 启动即退出并提示 'device is missing CPU features geniex requires'">
+    aarch64 Linux 版本以 **armv8.2-a** 编译，启用了 `fp16`、`dotprod`、`lse`（原子指令）与 `rdm` 扩展。基线 armv8.0 的板子（部分无 NPU 的 Dragonwing IoT SoC）不实现这些指令，因此 `geniex` 会在启动时给出明确错误并退出，而不是在运行中途抛出原始的 `SIGILL: illegal instruction`。
+
+    该检查是全局的：所有后端都需要这些指令，因此把 `--compute` 切到 `cpu`、`gpu` 或 `npu` 都无济于事。查看你的 CPU 报告了哪些特性：
+
+    ```bash bash
+    LD_SHOW_AUXV=1 /bin/true | grep AT_HWCAP   # 查找 atomics、asimdrdm、asimddp、fphp、asimdhp
+    cat /proc/cpuinfo | grep Features          # 相同特性，内核使用的名称
+    ```
+
+    若缺少这些特性，该设备无法运行当前版本。请带上以上输出到 [GitHub Issues](https://github.com/qualcomm/GenieX/issues) 或 Slack 反馈。
+  </Accordion>
 </AccordionGroup>
 
 ## **Android**

--- a/docs/en/resources/troubleshooting.mdx
+++ b/docs/en/resources/troubleshooting.mdx
@@ -93,6 +93,19 @@ import Feedback from "/snippets/page-feedback.mdx";
   <Accordion title="`--compute hybrid` runs but at CPU speed (silent NPU fallback)">
     If the Hexagon driver can't load (see the entry above), `hybrid` still produces correct output — it just runs entirely on CPU, so the failure is silent. Confirm the NPU is actually engaged by running with `GGML_HEX_VERBOSE=1`; you should see `Hexagon Arch version vNN` and a `libggml-htp-vNN.so` session. No such lines means it fell back to CPU.
   </Accordion>
+
+  <Accordion title="`geniex` exits with 'device is missing CPU features geniex requires'">
+    The aarch64 Linux build is compiled for **armv8.2-a** with the `fp16`, `dotprod`, `lse` (atomics), and `rdm` extensions. Baseline armv8.0 boards — some Dragonwing IoT SoCs with no NPU — don't implement these, so `geniex` stops at startup with a clear error rather than crashing with a raw `SIGILL: illegal instruction` partway through a run.
+
+    This check is global: every backend needs those instructions, so switching `--compute` to `cpu`, `gpu`, or `npu` won't help on such a device. Check what your CPU reports:
+
+    ```bash bash
+    LD_SHOW_AUXV=1 /bin/true | grep AT_HWCAP   # look for atomics, asimdrdm, asimddp, fphp, asimdhp
+    cat /proc/cpuinfo | grep Features          # same features, under the kernel's names
+    ```
+
+    If those features are absent, the device can't run the current build. Report it in [GitHub Issues](https://github.com/qualcomm/GenieX/issues) or Slack with the output above.
+  </Accordion>
 </AccordionGroup>
 
 ## **Android**

--- a/sdk/src/ml.cpp
+++ b/sdk/src/ml.cpp
@@ -85,16 +85,16 @@ int32_t geniex_init(void) {
     SetConsoleOutputCP(CP_UTF8);
 #endif
 
-    // Checked before any logging: a logging macro could itself compile to an
-    // armv8.2/LSE instruction, which would SIGILL on the very CPUs this guards.
+    GENIEX_LOG_DEBUG("initializing ml");
+
+    // Bail before scan_plugins loads a backend built with armv8.2 instructions
+    // this CPU can't run, which would otherwise SIGILL deep in inference.
     if (!cpu_features_supported()) {
         GENIEX_LOG_ERROR(
             "this device's CPU lacks features required by geniex; "
             "running would crash with an illegal instruction");
         return GENIEX_ERROR_COMMON_NOT_SUPPORTED;
     }
-
-    GENIEX_LOG_DEBUG("initializing ml");
 
     try {
         Registry::instance().scan_plugins();

--- a/sdk/src/ml.cpp
+++ b/sdk/src/ml.cpp
@@ -31,6 +31,21 @@ void* _crypto_dummy = (void*)OpenSSL_version;
 #include <windows.h>
 #endif
 
+// Baseline armv8.0 boards (e.g. unoq) lack the armv8.2 features this build bakes
+// in, so bail cleanly instead of SIGILL. Keep in sync with -march. See #1217.
+#if defined(__linux__) && defined(__aarch64__)
+#include <asm/hwcap.h>
+#include <sys/auxv.h>
+
+static bool cpu_features_supported() {
+    unsigned long need =
+        HWCAP_ATOMICS | HWCAP_ASIMDRDM | HWCAP_ASIMDDP | HWCAP_FPHP | HWCAP_ASIMDHP | HWCAP_CRC32;
+    return (getauxval(AT_HWCAP) & need) == need;
+}
+#else
+static bool cpu_features_supported() { return true; }
+#endif
+
 using namespace geniex;
 
 // Default log handler — always compiled. Emits to stderr with optional ANSI
@@ -72,6 +87,13 @@ int32_t geniex_init(void) {
 #endif
 
     GENIEX_LOG_DEBUG("initializing ml");
+
+    if (!cpu_features_supported()) {
+        GENIEX_LOG_ERROR(
+            "this device's CPU lacks features required by geniex; "
+            "running would crash with an illegal instruction");
+        return GENIEX_ERROR_COMMON_NOT_SUPPORTED;
+    }
 
     try {
         Registry::instance().scan_plugins();

--- a/sdk/src/ml.cpp
+++ b/sdk/src/ml.cpp
@@ -38,8 +38,7 @@ void* _crypto_dummy = (void*)OpenSSL_version;
 #include <sys/auxv.h>
 
 static bool cpu_features_supported() {
-    unsigned long need =
-        HWCAP_ATOMICS | HWCAP_ASIMDRDM | HWCAP_ASIMDDP | HWCAP_FPHP | HWCAP_ASIMDHP | HWCAP_CRC32;
+    unsigned long need = HWCAP_ATOMICS | HWCAP_ASIMDRDM | HWCAP_ASIMDDP | HWCAP_FPHP | HWCAP_ASIMDHP | HWCAP_CRC32;
     return (getauxval(AT_HWCAP) & need) == need;
 }
 #else
@@ -86,14 +85,16 @@ int32_t geniex_init(void) {
     SetConsoleOutputCP(CP_UTF8);
 #endif
 
-    GENIEX_LOG_DEBUG("initializing ml");
-
+    // Checked before any logging: a logging macro could itself compile to an
+    // armv8.2/LSE instruction, which would SIGILL on the very CPUs this guards.
     if (!cpu_features_supported()) {
         GENIEX_LOG_ERROR(
             "this device's CPU lacks features required by geniex; "
             "running would crash with an illegal instruction");
         return GENIEX_ERROR_COMMON_NOT_SUPPORTED;
     }
+
+    GENIEX_LOG_DEBUG("initializing ml");
 
     try {
         Registry::instance().scan_plugins();


### PR DESCRIPTION
## Problem

Fixes #1217. On an unoq board (baseline armv8.0 aarch64 Linux, no NPU), `geniex infer --compute cpu` crashed with a raw `SIGILL` inside `geniex_init()` before inference began.

Root cause: the shipped aarch64-linux build (`sdk/cmake/arm64-linux-gnu.cmake`, `-march=armv8.2-a+fp16+dotprod`) bakes in armv8.2 features unconditionally. The first illegal instruction is an LSE atomic (`ldaddal`, armv8.1); dotprod/fp16 kernels would fault next. A baseline armv8.0 core has none of these.

## Fix

- **SDK** (`sdk/src/ml.cpp`): `geniex_init` probes `getauxval(AT_HWCAP)` for the non-baseline features this build uses (LSE, RDM, dotprod, fp16, crc32) and returns `GENIEX_ERROR_COMMON_NOT_SUPPORTED` instead of letting the process SIGILL. The probe itself emits none of the guarded instructions.
- **Go binding** (`bindings/go/ml.go`): `Init()` now returns `error`.
- **CLI**: `common.InitSDK()` maps the generic `NOT_SUPPORTED` code to a CPU-specific sentinel (`ErrCPUUnsupported`) so it shows a dedicated hint rather than colliding with the unsupported-model-type hint. `infer`, `serve`, and `version` handle the init error.

## Verification

Reproduced and verified under QEMU (`qemu-aarch64`): the old `armv8.2+dotprod` build takes `signal 4 (Illegal instruction)` on `-cpu cortex-a53` (no LSE/fp16/dotprod, emulating unoq) and runs fine on `-cpu neoverse-n1`. With the guard, `geniex_init` returns `NOT_SUPPORTED` cleanly on cortex-a53. A unit test locks the CLI hint-mapping order.

## Notes

This detects and reports rather than newly enabling baseline CPUs — matches the issue's "exit with a clear error, no raw SIGILL" acceptance criterion. Enabling armv8.0 boards for real (baseline build or runtime dispatch) would be a separate change.