### PR TITLE
chore(sdk): bump llama.cpp to b10019

### DIFF
--- a/sdk/plugins/llama_cpp/CMakeLists.txt
+++ b/sdk/plugins/llama_cpp/CMakeLists.txt
@@ -25,7 +25,7 @@ if(GGML_HEXAGON)
     set(_HEXAGON_BDIR ${CMAKE_BINARY_DIR}/third-party/llama.cpp/ggml/src/ggml-hexagon)
     set(_INSTALL_COMMANDS)
     set(_HTP_PREFIX_DIRS)
-    foreach(_V IN ITEMS v68 v69 v73 v75 v79 v81)
+    foreach(_V IN ITEMS v73 v75 v79 v81)
         list(APPEND _INSTALL_COMMANDS
             COMMAND ${CMAKE_COMMAND} --install
                 ${_HEXAGON_BDIR}/htp-${_V}-prefix/src/htp-${_V}-build
@@ -40,7 +40,7 @@ if(GGML_HEXAGON)
     )
     add_custom_target(install-htp-skels
         ${_INSTALL_COMMANDS}
-        DEPENDS htp-v68 htp-v69 htp-v73 htp-v75 htp-v79 htp-v81
+        DEPENDS htp-v73 htp-v75 htp-v79 htp-v81
         COMMENT "Installing HTP skel libraries"
     )
     # inf2cat signing depends on the .so files being in ${_HEXAGON_BDIR} and
@@ -52,7 +52,7 @@ if(GGML_HEXAGON)
 
     # Install HTP skels and catalog into pkg layout alongside ggml-hexagon.
     set(_HTP_FILES)
-    foreach(_V IN ITEMS v68 v69 v73 v75 v79 v81)
+    foreach(_V IN ITEMS v73 v75 v79 v81)
         list(APPEND _HTP_FILES ${_HEXAGON_BDIR}/libggml-htp-${_V}.so)
     endforeach()
     install(FILES ${_HTP_FILES} DESTINATION lib/llama_cpp)


### PR DESCRIPTION
## What

Retarget the vendored `third-party/llama.cpp` submodule from `b9775` to the latest tag `b10019`.

## Why / adaptation

Upstream [#24954](https://github.com/ggml-org/llama.cpp/pull/24954) dropped the **v68/v69 HTP skel targets** — the new set is `v73/v75/v79/v81`. Our `install-htp-skels` wrapper in `sdk/plugins/llama_cpp/CMakeLists.txt` still referenced the removed `htp-v68`/`htp-v69` targets, so the build failed with:

```
ninja: error: 'plugins/llama_cpp/htp-v68', needed by 'install-htp-skels', missing and no known rule to make it
```

Dropped v68/v69 from all three skel version lists (build deps, install commands, pkg-layout copy) to match the new upstream set.

The GenieX `llama-hexagon-release-sessions` patch still applies cleanly against the new tip — no refresh needed.

## Verification

Built end-to-end on **qcs (Windows arm64 Snapdragon)** with the `arm64-windows-snapdragon-release` preset:

- SDK configures, builds (`geniex_plugin.dll` links), and installs cleanly.
- `geniex.dll` and the `v73/v75/v79/v81` skels land in `pkg-geniex/`.

Also builds locally on Linux (Vulkan).