### PR TITLE
fix(python): exclude resumed bytes from download speed

### DIFF
--- a/bindings/python/geniex/_progress.py
+++ b/bindings/python/geniex/_progress.py
@@ -28,6 +28,7 @@ class _TqdmProgress:
             if bar is None:
                 bar = tqdm(
                     total=f.total_bytes if f.total_bytes > 0 else None,
+                    initial=f.downloaded_bytes,
                     unit='B',
                     unit_scale=True,
                     unit_divisor=1024,

--- a/bindings/python/tests/test_progress.py
+++ b/bindings/python/tests/test_progress.py
@@ -57,6 +57,22 @@ def test_tqdm_progress_creates_bar_per_file():
     assert p._bars == {}
 
 
+def test_tqdm_progress_seeds_initial_from_downloaded():
+    p = _progress._TqdmProgress()
+    try:
+        # Resuming a partial download: the first callback already reports a
+        # large downloaded count. tqdm's rate must exclude those pre-existing
+        # bytes, so the bar is seeded with initial=downloaded_bytes.
+        p([FileProgress('a.gguf', 800, 1000)])
+        bar = p._bars['a.gguf']
+        assert bar.format_dict['initial'] == 800
+        assert bar.n == 800
+        p([FileProgress('a.gguf', 850, 1000)])
+        assert bar.n == 850
+    finally:
+        p.finish()
+
+
 def test_tqdm_progress_updates_existing_bar():
     p = _progress._TqdmProgress()
     try:


### PR DESCRIPTION
Addresses qcom-ai-hub/geniex#1252 (issue lives in the mirror repo; cross-repo keyword won't auto-close).

Seed the tqdm bar with `initial=downloaded_bytes` so a resumed pull's reported speed reflects only bytes transferred in the current session, not the bytes already on disk from a previous run.

The Rust model-manager reports `downloaded_bytes` as the cumulative on-disk total (correct for the percentage). Only the display layer needs to know how much of that was pre-existing. tqdm's `initial=` is built for exactly this — rate is computed as `(n - initial) / elapsed`. The Go CLI's `schollz/progressbar` has no equivalent knob (checked through v3.19.1) and is left unchanged.

## Test plan
- [x] Resume simulation: baseline 800MB already downloaded, +50MB this session over ~0.2s → tqdm shows ~240 MB/s, not ~4 GB/s; percentage still advances 80%→85%.