### PR TITLE
fix(ci): bump Windows Hexagon SDK to 6.6.0.0 for parity with Linux/Android

### DIFF
--- a/.github/actions/setup-snapdragon-sdks/action.yml
+++ b/.github/actions/setup-snapdragon-sdks/action.yml
@@ -9,11 +9,11 @@ inputs:
   hexagon-version:
     description: "Hexagon SDK version"
     required: false
-    default: "6.4.0.2"
+    default: "6.6.0.0"
   hexagon-tools-version:
     description: "Hexagon tools version under $HEXAGON_SDK_ROOT/tools/HEXAGON_Tools"
     required: false
-    default: "19.0.04"
+    default: "19.0.07"
 
 runs:
   using: "composite"


### PR DESCRIPTION
## Summary

- Bumps the two defaults in `.github/actions/setup-snapdragon-sdks/action.yml`: `hexagon-version` 6.4.0.2 → 6.6.0.0 and `hexagon-tools-version` 19.0.04 → 19.0.07.
- Windows was missed by the earlier Linux/Android toolchain bump (a533af4d + cfdc7e11 + c313655a) that moved those platforms off SDK 6.4.0.2 to fix the miscompiled `libggml-htp-v75.so` on QCS8275.
- Both consumers (`_build-sdk.yml` windows-arm64 branch and `build-llama-cpp-windows.yml`) rely on the composite action's defaults, so no other file needs changing.

Related: qcom-ai-hub/geniex#1260.

## Test plan

- [x] Local `arm64-windows-snapdragon-release` SDK bridge build passes end-to-end under `HEXAGON_SDK_ROOT=C:\Qualcomm\Hexagon_SDK\6.6.0.0` (this host is Hexagon v73, so this covers v73 skel + build-tree only; the v75 miscompile fix is only observable on QCS8275).
- [x] Local `geniex-bench.exe` with `ai/smollm2` reaches `[ok]` on `--device hybrid`, `--device npu` (HTP0 v73 skel), `--device gpu` (Adreno X1-85 OpenCL), and `--device cpu` — all four paths still initialize and run to `stop_reason: length`.