### PR TITLE
fix(sdk): fix gemma-4-E2B VLM load and MTP quant selection

### DIFF
--- a/sdk/model-manager/crates/core/src/manifest_builder.rs
+++ b/sdk/model-manager/crates/core/src/manifest_builder.rs
@@ -88,6 +88,8 @@ pub fn infer_manifest_from_names(
         if lname.ends_with(".gguf") {
             if is_mmproj_filename(&lname) {
                 mmprojs.push(n);
+            } else if lname.contains("mtp") {
+                // TODO: MTP draft models can't load standalone; skip for now.
             } else {
                 let quant = extract_quant(n).unwrap_or_else(|| "default".to_string());
                 ggufs.entry(quant).or_default().push(n);
@@ -723,6 +725,30 @@ mod tests {
         assert!(m.model_file.contains_key("Q4_K_M"));
         assert_eq!(m.mmproj_file.name, "mmproj-F16.gguf");
         assert_eq!(m.model_name, "Repo");
+    }
+
+    #[test]
+    fn skips_mtp_draft_gguf() {
+        // The MTP draft's Q4_0 tag would otherwise win QUANT_PRIORITY over the
+        // base model's Q4_K_XL, but it can't load standalone.
+        let (names, sizes) = sizes_of(&[
+            ("gemma-4-E2B-it-qat-UD-Q4_K_XL.gguf", 2_620_368_960),
+            ("MTP/mtp-gemma-4-E2B-it-Q4_0.gguf", 59_235_648),
+            ("mmproj-F32.gguf", 1_903_027_008),
+        ]);
+        let m = infer_manifest_from_names(
+            "unsloth/gemma-4-E2B-it-qat-GGUF",
+            &names,
+            &sizes,
+            Default::default(),
+        )
+        .unwrap();
+        assert!(m.model_file.contains_key("Q4_K_XL"));
+        assert!(
+            !m.model_file.contains_key("Q4_0"),
+            "MTP draft must not be a selectable quant: {:?}",
+            m.model_file.keys().collect::<Vec<_>>()
+        );
     }
 
     #[test]

--- a/sdk/plugins/llama_cpp/src/vlm.cpp
+++ b/sdk/plugins/llama_cpp/src/vlm.cpp
@@ -273,6 +273,7 @@ int32_t LlamaVlm::generate(const geniex_VlmGenerateInput* input, geniex_VlmGener
             // prompt_utf8 already has chat template and media markers applied
             mtmd_input_text text;
             text.text          = new_text_portion.c_str();
+            text.text_len      = new_text_portion.length();
             text.add_special   = this->n_past == 0;  // add BOS only on first message
             text.parse_special = true;
 


### PR DESCRIPTION
## Summary

Two independent fixes that together restore `unsloth/gemma-4-E2B-it-qat-GGUF` end-to-end.

- **VLM tokenize `std::bad_alloc`**: the b10019 llama.cpp bump added `text_len` to `mtmd_input_text` and made `mtmd_tokenize` read it instead of `strlen`. The VLM path never set it, so every `generate` (even text-only) threw `std::bad_alloc`. Set `text_len` from the new-text length.
- **MTP draft picked as the model**: repos like `gemma-4-E2B-it-qat-GGUF` ship an MTP draft GGUF whose `Q4_0` tag wins `QUANT_PRIORITY` over the base weights. The draft loads with the `GEMMA4_ASSISTANT` arch, which cannot stand alone (`Gemma4Assistant requires ctx_other to be set`), so it fails model load. Exclude GGUFs whose name contains `mtp` from quant candidates.

## Test plan

- [x] `cargo test -p model-manager-core --lib` — 159 pass, incl. new `skips_mtp_draft_gguf`
- [x] Local (Linux/Vulkan): `infer gemma-4-E2B -c hybrid` generates correctly
- [x] Local: fresh `pull` of the repo resolves quants to `[Q2_K_XL, Q4_K_XL]` — MTP excluded
- [x] qcs (Windows arm64 Snapdragon): SDK rebuilds; `:Q4_0` reports not-found; base model loads and infers end-to-end