### PR TITLE
fix(sdk): enable clip GPU backend when n_gpu_layers is -1

### DIFF
--- a/sdk/plugins/llama_cpp/src/vlm.cpp
+++ b/sdk/plugins/llama_cpp/src/vlm.cpp
@@ -82,7 +82,7 @@ int32_t LlamaVlm::create(const geniex_VlmCreateInput* input) {
     // Initialize vision context if mmproj_path provided
     if (input->mmproj_path) {
         mtmd_context_params mparams = mtmd_context_params_default();
-        mparams.use_gpu             = config.n_gpu_layers > 0;
+        mparams.use_gpu             = config.n_gpu_layers != 0;
         mparams.print_timings       = false;
         mparams.n_threads           = 4;
         // Zack TODO: elegant fix this error:  no member named 'verbosity' in 'mtmd_context_params'


### PR DESCRIPTION
## What

The mtmd/clip vision encoder was silently falling back to CPU on the default `npu`/`hybrid` device path.

## Why

`vlm.cpp` set `mtmd_context_params.use_gpu = config.n_gpu_layers > 0`. But in llama.cpp `n_gpu_layers < 0` means "all layers", and the CLI/binding default for `npu`/`hybrid`/`gpu` is `-1`. Since `-1 > 0` is false, `use_gpu` was false, so `clip_ctx` never initialized a GPU/HTP backend and dropped to CPU (`clip.cpp` backend selection).

## Fix

Treat any non-zero `n_gpu_layers` as GPU-enabled (`!= 0`). Only the `cpu` alias (`ngl = 0`) forces clip to CPU, matching the intended semantics.