### PR TITLE
ci(release): use Trusted Publishing for TestPyPI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -423,6 +423,9 @@ jobs:
     if: needs.resolve-tag.outputs.is_prerelease == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      # OIDC token for TestPyPI Trusted Publishing — no API token needed.
+      id-token: write
     steps:
       - uses: actions/download-artifact@v8
         with:
@@ -433,11 +436,8 @@ jobs:
         uses: pypa/gh-action-pypi-publish@v1.14.1
         with:
           repository-url: https://test.pypi.org/legacy/
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           packages-dir: dist/
           skip-existing: true
-          # API-token auth, not Trusted Publishing — attestations are a no-op.
-          attestations: false
 
   # Stable (bare vX.Y.Z) tags publish to production PyPI.
   publish-pypi:


### PR DESCRIPTION
## Summary

- Drop `TEST_PYPI_API_TOKEN` from `publish-testpypi`; add `permissions: id-token: write` and let `pypa/gh-action-pypi-publish` mint attestations from OIDC.
- Mirrors the shape of `publish-pypi` after commit `c929233a`. TestPyPI was the only upload path still on an API token.
- Depends on Trusted Publisher being registered on TestPyPI for all three sibling projects (`geniex`, `geniex-llama-cpp`, `geniex-qairt`) with owner `qualcomm`, repo `GenieX`, workflow `release.yml`, no environment — pypa's log emits the self-service URLs on every prerelease run.

## Test plan

- [ ] Cut a `v0.3.17-alpha.1` tag after merge and confirm `publish-testpypi` uploads all three sdists (200 OK, no 403). Ready as draft until then — TestPyPI must be configured first.