### PR TITLE
fix(server): return valid tool_call id/type and JSON-encode chat template arguments

### DIFF
--- a/cli/server/handler/chat.go
+++ b/cli/server/handler/chat.go
@@ -149,9 +149,8 @@ func chatCompletionsLLM(c *gin.Context, param ChatCompletionRequest, modelParam 
 		if toolCalls := msg.GetToolCalls(); len(toolCalls) > 0 {
 			for _, tc := range toolCalls {
 				messages = append(messages, geniex_sdk.LlmChatMessage{
-					Role: geniex_sdk.LlmRole(*msg.GetRole()),
-					Content: fmt.Sprintf(`<tool_call>{"name":"%s","arguments":"%s"}</tool_call>`,
-						tc.GetFunction().Name, tc.GetFunction().Arguments),
+					Role:    geniex_sdk.LlmRole(*msg.GetRole()),
+					Content: formatToolCallBlock(tc.GetFunction().Name, tc.GetFunction().Arguments),
 				})
 			}
 			continue
@@ -320,8 +319,7 @@ func chatCompletionsVLM(c *gin.Context, param ChatCompletionRequest, modelParam 
 			for _, tc := range toolCalls {
 				contents = append(contents, geniex_sdk.VlmContent{
 					Type: geniex_sdk.VlmContentTypeText,
-					Text: fmt.Sprintf(`<tool_call>{"name":"%s","arguments":"%s"}</tool_call>`,
-						tc.GetFunction().Name, tc.GetFunction().Arguments),
+					Text: formatToolCallBlock(tc.GetFunction().Name, tc.GetFunction().Arguments),
 				})
 			}
 			messages = append(messages, geniex_sdk.VlmChatMessage{
@@ -628,9 +626,13 @@ func writeBlockingResponse(c *gin.Context, fullText string, profile geniex_sdk.P
 			choice := openai.ChatCompletionChoice{}
 			choice.FinishReason = "tool_calls"
 			choice.Message.Role = constant.Assistant(openai.MessageRoleAssistant)
-			choice.Message.ToolCalls = []openai.ChatCompletionMessageToolCallUnion{{Function: toolCall}}
+			choice.Message.ToolCalls = []openai.ChatCompletionMessageToolCallUnion{{
+				ID:       fmt.Sprintf("call_%d", rand.Uint32()),
+				Type:     "function",
+				Function: toolCall,
+			}}
 			c.JSON(http.StatusOK, openai.ChatCompletion{
-				ID:      fmt.Sprintf("call_%d", rand.Uint32()),
+				ID:      fmt.Sprintf("chatcmpl-%d", rand.Uint32()),
 				Choices: []openai.ChatCompletionChoice{choice},
 				Usage:   profile2Usage(profile),
 			})
@@ -716,7 +718,8 @@ func streamToolCall(c *gin.Context, dataCh <-chan string, wait func() error, inc
 			Choices: []openai.ChatCompletionChunkChoice{{
 				Delta: openai.ChatCompletionChunkChoiceDelta{
 					ToolCalls: []openai.ChatCompletionChunkChoiceDeltaToolCall{{
-						ID: fmt.Sprintf("call_%d", rand.Uint32()),
+						ID:   fmt.Sprintf("call_%d", rand.Uint32()),
+						Type: "function",
 						Function: openai.ChatCompletionChunkChoiceDeltaToolCallFunction{
 							Name:      toolCall.Name,
 							Arguments: toolCall.Arguments,
@@ -762,6 +765,31 @@ func mapFinishReason(stopReason string) string {
 }
 
 // =============== tool-call parsing ===============
+
+// formatToolCallBlock renders an assistant tool_calls turn into the
+// <tool_call>...</tool_call> block the chat template expects, using proper
+// JSON encoding. Raw string concatenation is unsafe: the OpenAI schema stores
+// arguments as an already-encoded JSON string (e.g. `{"city":"San Diego"}`),
+// so splicing it into `"arguments":"%s"` produces malformed JSON that crashes
+// the C-side chat-template applier.
+func formatToolCallBlock(name string, arguments string) string {
+	args := ast.NewRaw(arguments)
+	if !args.Valid() {
+		// arguments the model sent aren't valid JSON — treat as a plain
+		// string so the payload still parses on the way in.
+		args = ast.NewString(arguments)
+	}
+	payload := ast.NewObject([]ast.Pair{
+		ast.NewPair("name", ast.NewString(name)),
+		ast.NewPair("arguments", args),
+	})
+	encoded, err := payload.MarshalJSON()
+	if err != nil {
+		slog.Warn("Failed to marshal tool_call payload, falling back to text", "error", err)
+		return fmt.Sprintf("<tool_call>%s</tool_call>", arguments)
+	}
+	return fmt.Sprintf("<tool_call>%s</tool_call>", encoded)
+}
 
 var toolCallRegex = regexp.MustCompile(`<tool_call>([\s\S]+)<\/tool_call>` + "|" + "```json([\\s\\S]+)```")
 

--- a/cli/server/handler/chat_test.go
+++ b/cli/server/handler/chat_test.go
@@ -1,0 +1,87 @@
+// Copyright (c) 2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
+package handler
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestFormatToolCallBlockValidJSON guards the Round-2 assistant-turn
+// concatenation path: the previous fmt.Sprintf-based implementation embedded
+// the OpenAI-schema `arguments` (already a JSON string) via %s, producing
+// invalid JSON that crashed the C-side chat-template applier.
+func TestFormatToolCallBlockValidJSON(t *testing.T) {
+	cases := []struct {
+		name      string
+		toolName  string
+		arguments string
+	}{
+		{"simple", "get_current_weather", `{"city":"San Diego"}`},
+		{"nested", "search", `{"q":"quoted \"word\"","limit":10}`},
+		{"empty_object", "list_files", `{}`},
+		{"array", "batch", `[1,2,3]`},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := formatToolCallBlock(tc.toolName, tc.arguments)
+			if !strings.HasPrefix(out, "<tool_call>") || !strings.HasSuffix(out, "</tool_call>") {
+				t.Fatalf("missing tool_call tags: %q", out)
+			}
+			inner := strings.TrimSuffix(strings.TrimPrefix(out, "<tool_call>"), "</tool_call>")
+
+			// The inner payload must be parseable JSON — this is the
+			// invariant the CGO crash violates when %s splices a raw
+			// JSON string into "arguments":"%s".
+			var parsed struct {
+				Name      string          `json:"name"`
+				Arguments json.RawMessage `json:"arguments"`
+			}
+			if err := json.Unmarshal([]byte(inner), &parsed); err != nil {
+				t.Fatalf("inner payload is not valid JSON: %v (payload=%q)", err, inner)
+			}
+			if parsed.Name != tc.toolName {
+				t.Errorf("name mismatch: got %q, want %q", parsed.Name, tc.toolName)
+			}
+			// Arguments should round-trip as the original JSON structure —
+			// compare parsed forms so key ordering / whitespace differences
+			// from the JSON encoder don't spuriously fail the check.
+			var gotArgs, wantArgs any
+			if err := json.Unmarshal(parsed.Arguments, &gotArgs); err != nil {
+				t.Fatalf("arguments not valid JSON: %v", err)
+			}
+			if err := json.Unmarshal([]byte(tc.arguments), &wantArgs); err != nil {
+				t.Fatalf("test-case arguments not valid JSON: %v", err)
+			}
+			gotJSON, _ := json.Marshal(gotArgs)
+			wantJSON, _ := json.Marshal(wantArgs)
+			if string(gotJSON) != string(wantJSON) {
+				t.Errorf("arguments mismatch: got %s, want %s", gotJSON, wantJSON)
+			}
+		})
+	}
+}
+
+// TestFormatToolCallBlockInvalidArgumentsFallback guards the graceful path
+// when a model emits invalid JSON as `arguments`: the block must still be
+// well-formed JSON so the chat template doesn't crash.
+func TestFormatToolCallBlockInvalidArgumentsFallback(t *testing.T) {
+	out := formatToolCallBlock("weird", "not valid json {")
+	inner := strings.TrimSuffix(strings.TrimPrefix(out, "<tool_call>"), "</tool_call>")
+
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(inner), &parsed); err != nil {
+		t.Fatalf("fallback payload is not valid JSON: %v (payload=%q)", err, inner)
+	}
+	if parsed["name"] != "weird" {
+		t.Errorf("name mismatch: got %v", parsed["name"])
+	}
+	// Malformed arguments get wrapped as a JSON string so the payload stays
+	// well-formed rather than corrupting downstream parsers.
+	if _, ok := parsed["arguments"].(string); !ok {
+		t.Errorf("expected arguments to be encoded as string, got %T", parsed["arguments"])
+	}
+}


### PR DESCRIPTION
## Summary

Two independent defects on the chat-completions tool-calling path, both triggered when the client follows the standard OpenAI SDK idiom `messages.append(response.choices[0].message)` for round 2.

**Bug 1 — response missing `id` / `type`.** `writeBlockingResponse` and `streamToolCall` left `ToolCallUnion.ID` and `Type` as empty strings. The OpenAI schema requires a server-generated `id` (used to correlate the round-2 tool result via `tool_call_id`) and `type: \"function\"`. The `call_xxx` value was mistakenly assigned to `ChatCompletion.ID` (the top-level response id, which should be `chatcmpl-...`).

**Bug 2 — CGO crash on round 2.** `chatCompletionsLLM` / `chatCompletionsVLM` built the round-2 `<tool_call>` block via `fmt.Sprintf(\"...\\\"arguments\\\":\\\"%s\\\"...\", tc.GetFunction().Arguments)`. The OpenAI schema stores `arguments` as an already-encoded JSON string (e.g. `{\"city\":\"San Diego\"}`), so splicing it into `\"arguments\":\"%s\"` produced malformed JSON that crashed the C-side chat-template applier with `Access Violation 0xc0000005` in `_Cfunc_geniex_llm_apply_chat_template`.

Introduces `formatToolCallBlock`, which builds the payload with the existing `sonic ast` API so the resulting block is always well-formed JSON regardless of what the model emitted in `arguments`. Adds unit tests pinning this invariant for four representative argument shapes plus the malformed-input fallback path.

## Test plan

- [x] `go vet ./server/handler/...` clean
- [x] New `TestFormatToolCallBlockValidJSON` / `TestFormatToolCallBlockInvalidArgumentsFallback` cover both invariants
- [x] Baseline reproduction on Windows ARM64 (SC8480XP) with `unsloth/Qwen3-4B-GGUF:Q4_0`:
  - Round 1 response `tool_calls[0].id = \"\"`, `type = \"\"` (Bug 1)
  - Round 2 echoing the round-1 assistant message back reproduces the CGO Access Violation 100% (Bug 2, stack: `_Cfunc_geniex_llm_apply_chat_template`)
- [ ] Post-fix end-to-end on Windows ARM64 (SC8480XP) — will pull the CI-built `cli-setup-windows-arm64` artifact from this PR run, replace `geniex.exe` on the device, and rerun the same repro to confirm both invariants hold.

## Repro (baseline, GenieX v0.3.16)

**Round 1 — returns empty id/type:**

```bash
curl http://127.0.0.1:18181/v1/chat/completions \
  -H \"Content-Type: application/json\" \
  -d '{
    \"model\": \"unsloth/Qwen3-4B-GGUF:Q4_0\",
    \"messages\": [{\"role\":\"user\",\"content\":\"What is the weather in San Diego right now?\"}],
    \"tools\": [{\"type\":\"function\",\"function\":{\"name\":\"get_current_weather\",\"description\":\"Get the current weather for a given city.\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\"}},\"required\":[\"city\"]}}}],
    \"stream\": false
  }'
```

Observed:
```json
\"tool_calls\": [{\"id\": \"\", \"type\": \"\", \"function\": {\"name\":\"get_current_weather\",\"arguments\":\"{\\\"city\\\": \\\"San Diego\\\"}\"}}]
```

**Round 2 — CGO crash** when the assistant turn is echoed back exactly as returned by round 1 (Pydantic-default fields included), which is what `messages.append(first.choices[0].message)` produces in the OpenAI Python SDK.