### PR TITLE
fix(server): populate id and type on tool_calls response

### DIFF
--- a/cli/server/handler/chat.go
+++ b/cli/server/handler/chat.go
@@ -628,9 +628,12 @@ func writeBlockingResponse(c *gin.Context, fullText string, profile geniex_sdk.P
 			choice := openai.ChatCompletionChoice{}
 			choice.FinishReason = "tool_calls"
 			choice.Message.Role = constant.Assistant(openai.MessageRoleAssistant)
-			choice.Message.ToolCalls = []openai.ChatCompletionMessageToolCallUnion{{Function: toolCall}}
+			choice.Message.ToolCalls = []openai.ChatCompletionMessageToolCallUnion{{
+				ID:       fmt.Sprintf("call_%d", rand.Uint32()),
+				Type:     "function",
+				Function: toolCall,
+			}}
 			c.JSON(http.StatusOK, openai.ChatCompletion{
-				ID:      fmt.Sprintf("call_%d", rand.Uint32()),
 				Choices: []openai.ChatCompletionChoice{choice},
 				Usage:   profile2Usage(profile),
 			})
@@ -716,7 +719,8 @@ func streamToolCall(c *gin.Context, dataCh <-chan string, wait func() error, inc
 			Choices: []openai.ChatCompletionChunkChoice{{
 				Delta: openai.ChatCompletionChunkChoiceDelta{
 					ToolCalls: []openai.ChatCompletionChunkChoiceDeltaToolCall{{
-						ID: fmt.Sprintf("call_%d", rand.Uint32()),
+						ID:   fmt.Sprintf("call_%d", rand.Uint32()),
+						Type: "function",
 						Function: openai.ChatCompletionChunkChoiceDeltaToolCallFunction{
 							Name:      toolCall.Name,
 							Arguments: toolCall.Arguments,


### PR DESCRIPTION
## Summary

`writeBlockingResponse` and `streamToolCall` in [cli/server/handler/chat.go](cli/server/handler/chat.go) both under-populated the `tool_calls[]` entries they emit:

- Non-streaming path built `ChatCompletionMessageToolCallUnion{Function: toolCall}` — leaving both `id` and `type` empty. Worse, the random `call_%d` id that was intended for the tool-call entry was accidentally stored on the top-level `ChatCompletion.ID` field (which per OpenAI spec is the completion id, not the tool-call id).
- Streaming path put the `call_%d` id in the right slot but still omitted `type`.

Symptoms on the client side:

1. `choices[0].message.tool_calls[0].id == ""` — clients can't correlate a `role="tool"` follow-up message to the request.
2. `choices[0].message.tool_calls[0].type == ""` — the OpenAI Python SDK deserializes this into a union whose `type` is empty. Echoing the message straight back in the next turn (the standard multi-turn tool-calling idiom) then causes the server to crash inside `geniex_llm_apply_chat_template` (cgo Access Violation), tearing down the whole `geniex serve` process.

Fix: set `ID` and `Type: "function"` on the union entry itself; stop writing the random id to `ChatCompletion.ID`.

## Test plan

- [x] Local `bazel run //cli -- serve` on Windows on Snapdragon → `curl POST /v1/chat/completions` with `tools=[get_weather]` now returns `tool_calls[0]={id: "call_2600331670", type: "function", function: {name: "get_weather", arguments: "{\"city\": \"Beijing\"}"}}` and top-level `id` empty (before: id/type both empty, `call_XXX` misplaced on the top-level).
- [x] Round-trip with the official `openai` Python SDK: `messages.append(first.choices[0].message)` + `role="tool"` follow-up now returns the final natural-language answer instead of crashing the server. Before this fix, the client had to hand-rebuild a dict with explicit `type: "function"` to avoid the cgo crash.