### PR TITLE
fix(sdk): fold :default quant to its lower-case sentinel

### DIFF
--- a/sdk/model-manager/crates/core/src/manifest_builder.rs
+++ b/sdk/model-manager/crates/core/src/manifest_builder.rs
@@ -36,6 +36,26 @@ pub struct ManifestHint {
 /// share.
 pub(crate) const QUANT_PRIORITY: &[&str] = &["Q4_0", "Q4_K_M", "Q8_0"];
 
+/// Bucket key for GGUFs whose filename carries no recognizable quant tag
+/// (e.g. an untagged FP16 export). Deliberately lower-case: it is a
+/// sentinel, not a real quant tag, and it is user-visible — in the
+/// precision picker, in "available:" error lists, and as a `:default`
+/// pull spec.
+pub const DEFAULT_QUANT: &str = "default";
+
+/// Canonicalize a user-supplied quant so it matches manifest keys: real
+/// tags are upper-cased (keys come from [`extract_quant`], which
+/// upper-cases), while any casing of [`DEFAULT_QUANT`] folds to the
+/// lower-case sentinel. Blanket upper-casing turned `:default` into
+/// `"DEFAULT"`, which no manifest ever keys (#1202).
+pub fn normalize_quant_tag(tag: &str) -> String {
+    if tag.eq_ignore_ascii_case(DEFAULT_QUANT) {
+        DEFAULT_QUANT.to_string()
+    } else {
+        tag.to_ascii_uppercase()
+    }
+}
+
 /// Infer a manifest by scanning `src_dir` for model files.
 pub fn infer_manifest_from_dir(
     name: &str,
@@ -91,7 +111,7 @@ pub fn infer_manifest_from_names(
             } else if lname.contains("mtp") {
                 // TODO: MTP draft models can't load standalone; skip for now.
             } else {
-                let quant = extract_quant(n).unwrap_or_else(|| "default".to_string());
+                let quant = extract_quant(n).unwrap_or_else(|| DEFAULT_QUANT.to_string());
                 ggufs.entry(quant).or_default().push(n);
             }
         } else if lname.ends_with("tokenizer.json") {
@@ -700,6 +720,38 @@ mod tests {
             m.extra_files.is_empty(),
             "single-file repo has no extras: {:?}",
             m.extra_files
+        );
+    }
+
+    #[test]
+    fn normalize_quant_tag_folds_default_and_upper_cases_tags() {
+        assert_eq!(normalize_quant_tag("q4_0"), "Q4_0");
+        assert_eq!(normalize_quant_tag("mxfp4"), "MXFP4");
+        assert_eq!(normalize_quant_tag("default"), DEFAULT_QUANT);
+        assert_eq!(normalize_quant_tag("DEFAULT"), DEFAULT_QUANT);
+        assert_eq!(normalize_quant_tag("Default"), DEFAULT_QUANT);
+    }
+
+    #[test]
+    fn quant_hint_default_selects_untagged_gguf() {
+        // #1202: Qwen/Qwen2-1.5B-Instruct-GGUF ships tagged quants plus an
+        // untagged fp16 export that lands in the "default" bucket. Pulling
+        // `:default` — the exact key the picker and error list advertise —
+        // must select that bucket, not fail with QuantNotFound.
+        let (names, sizes) = sizes_of(&[
+            ("qwen2-1_5b-instruct-q4_0.gguf", 1_000_000),
+            ("qwen2-1_5b-instruct-fp16.gguf", 3_100_000),
+        ]);
+        let hint = ManifestHint {
+            quant: Some(DEFAULT_QUANT.to_string()),
+            ..Default::default()
+        };
+        let m = infer_manifest_from_names("Qwen/Qwen2-1.5B-Instruct-GGUF", &names, &sizes, hint)
+            .unwrap();
+        assert_eq!(m.model_file.len(), 1);
+        assert_eq!(
+            m.model_file.get(DEFAULT_QUANT).map(|f| f.name.as_str()),
+            Some("qwen2-1_5b-instruct-fp16.gguf")
         );
     }
 

--- a/sdk/model-manager/crates/ffi/src/pull.rs
+++ b/sdk/model-manager/crates/ffi/src/pull.rs
@@ -5,7 +5,7 @@ use std::os::raw::{c_char, c_void};
 use std::path::PathBuf;
 
 use model_manager_core::config::StoreConfig;
-use model_manager_core::manifest_builder::ManifestHint;
+use model_manager_core::manifest_builder::{normalize_quant_tag, ManifestHint};
 use model_manager_core::mapping::{
     aihub_display_name_from_repo, canonicalize_model_name, docker_hub_repo_from_name,
     is_docker_hub_reference,
@@ -278,10 +278,13 @@ pub extern "C" fn geniex_model_pull(input: *const GenieXModelPullInput) -> i32 {
 
         // Thread `quant` into the manifest hint so `pull` only fetches
         // the requested quantization instead of every GGUF in the repo.
-        // Upper-cased here so the lookup in `manifest_builder::infer_*`
+        // Normalized here so the lookup in `manifest_builder::infer_*`
         // (against keys produced by `extract_quant`, which upper-cases)
-        // succeeds for bindings that don't normalize themselves.
-        let quant = unsafe { cstr_to_str(inp.quant) }.map(|s| s.to_ascii_uppercase());
+        // succeeds for bindings that don't normalize themselves. The
+        // untagged-GGUF bucket key is the lower-case "default" sentinel,
+        // so normalization folds its casing rather than blanket
+        // upper-casing (#1202: `pull <repo>:default` failed as "DEFAULT").
+        let quant = unsafe { cstr_to_str(inp.quant) }.map(normalize_quant_tag);
         // -1 (GENIEX_MODEL_TYPE_AUTO) leaves detection to the inferer; 0/1 force
         // the type so the manifest is written correctly in one shot.
         let model_type = match inp.model_type {

--- a/sdk/model-manager/crates/ffi/src/types.rs
+++ b/sdk/model-manager/crates/ffi/src/types.rs
@@ -7,6 +7,7 @@ use std::os::raw::{c_char, c_void};
 use std::panic::{catch_unwind, AssertUnwindSafe};
 
 use model_manager_core::error::Error;
+use model_manager_core::manifest_builder::normalize_quant_tag;
 
 use crate::logging;
 
@@ -158,15 +159,17 @@ pub unsafe fn free_cptr(ptr: *mut c_char) {
     }
 }
 
-/// Upper-case the `:QUANT` suffix of a model name. Manifest keys are
+/// Canonicalize the `:QUANT` suffix of a model name. Manifest keys are
 /// produced by `extract_quant`, which upper-cases (so `q4_0` -> `Q4_0`);
 /// without matching the lookup side, `pull <repo>:q4_0` fails for callers
-/// (Python, JNI) whose bindings don't already upper-case. Done here at the
-/// FFI boundary so the invariant is a single point of enforcement.
+/// (Python, JNI) whose bindings don't already upper-case. The untagged-GGUF
+/// bucket is keyed by the lower-case "default" sentinel, so that spelling
+/// folds down instead of up (#1202). Done here at the FFI boundary so the
+/// invariant is a single point of enforcement.
 pub fn normalize_quant_suffix(name: &str) -> String {
     match name.rsplit_once(':') {
         Some((base, quant)) if !quant.is_empty() => {
-            format!("{base}:{}", quant.to_ascii_uppercase())
+            format!("{base}:{}", normalize_quant_tag(quant))
         }
         _ => name.to_string(),
     }
@@ -240,6 +243,20 @@ mod tests {
         );
         // Trailing colon (no quant) → unchanged.
         assert_eq!(normalize_quant_suffix("Org/Repo:"), "Org/Repo:");
+    }
+
+    #[test]
+    fn normalize_quant_suffix_folds_default_sentinel() {
+        // #1202: the untagged-GGUF bucket is keyed "default" (lower-case);
+        // upper-casing the suffix made `<repo>:default` unmatchable.
+        assert_eq!(
+            normalize_quant_suffix("Qwen/Qwen2-1.5B-Instruct-GGUF:default"),
+            "Qwen/Qwen2-1.5B-Instruct-GGUF:default"
+        );
+        assert_eq!(
+            normalize_quant_suffix("Qwen/Qwen2-1.5B-Instruct-GGUF:DEFAULT"),
+            "Qwen/Qwen2-1.5B-Instruct-GGUF:default"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`geniex pull <repo>:default` — and picking `default` in the interactive precision picker — failed with:

```
Error: SDKError(Invalid model format), could not infer manifest from directory: requested quant "DEFAULT" not found; available: ["Q2_K", "Q3_K_M", "Q4_0", "Q4_K_M", "Q5_0", "Q5_K_M", "Q6_K", "Q8_0", "default"]
```

GGUFs whose filename carries no recognizable quant tag (e.g. an untagged fp16 export) are bucketed under the lower-case `default` sentinel by `manifest_builder`, but the FFI boundary blanket upper-cased every requested quant before the manifest-key lookup — so the exact spelling the picker and the error list advertise could never match. The same normalization runs on `:quant` name suffixes, so `run` / `remove <repo>:default` would hit the same `QuantNotFound` wall after a successful pull.

Changes:

- Name the sentinel (`DEFAULT_QUANT`) in `manifest_builder` and use it where untagged GGUFs are bucketed.
- Add a sentinel-aware `normalize_quant_tag` helper next to it: real tags upper-case exactly as before (`q4_0` → `Q4_0`, `mxfp4` → `MXFP4`), while any casing of `default` folds to the lower-case sentinel.
- Use the helper at both FFI normalization sites — `geniex_model_pull`'s quant hint and `normalize_quant_suffix` (used by `geniex_model_get_paths` / `geniex_model_remove`) — so the Go CLI, Python, and JNI bindings are all covered at the single point of enforcement.

## Test plan

- [x] `cargo test -p model-manager-core -p model-manager-ffi` — all green
- [x] New regression test `quant_hint_default_selects_untagged_gguf` models the `Qwen/Qwen2-1.5B-Instruct-GGUF` layout from the issue (tagged quants + untagged fp16) and pulls `:default`
- [x] New `normalize_quant_tag` / `normalize_quant_suffix` cases cover `default` / `DEFAULT` / `Default` folding and unchanged upper-casing of real tags
- [x] On-device `geniex pull Qwen/Qwen2-1.5B-Instruct-GGUF:default` (needs network + Snapdragon hardware)

Closes #1202

🤖 Generated with [Claude Code](https://claude.com/claude-code)
