### PR TITLE
feat(cli): gate windows update on installer signing

### DIFF
--- a/cli/cmd/geniex/update.go
+++ b/cli/cmd/geniex/update.go
@@ -44,6 +44,7 @@ const (
 	defaultNumWorkers = 16
 
 	linuxInstallScriptURL = releaseBaseURL + "install.sh"
+	windowsSignedURL      = releaseBaseURL + "windows-signed.txt"
 )
 
 func update() *cobra.Command {
@@ -90,6 +91,16 @@ func runUpdate(_ *cobra.Command, _ []string) error {
 	}
 	if runtime.GOOS != "windows" {
 		return fmt.Errorf("auto-update is not supported on %s/%s", runtime.GOOS, runtime.GOARCH)
+	}
+
+	// Skip until the published installer is code-signed.
+	signed, err := isWindowsSigned()
+	if err != nil {
+		return err
+	}
+	if !signed {
+		fmt.Println("Already up-to-date.")
+		return nil
 	}
 
 	mf, err := getManifest(latest)
@@ -207,6 +218,30 @@ func getManifest(tag string) (manifest, error) {
 		return mf, err
 	}
 	return mf, nil
+}
+
+// isWindowsSigned reports whether windows-signed.txt on S3 contains "true".
+func isWindowsSigned() (bool, error) {
+	req, err := http.NewRequest("GET", windowsSignedURL, nil)
+	if err != nil {
+		return false, err
+	}
+	req.Header.Set("User-Agent", userAgent)
+
+	resp, err := (&http.Client{Timeout: 10 * time.Second}).Do(req)
+	if err != nil {
+		return false, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return false, nil
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return false, err
+	}
+	return strings.EqualFold(strings.TrimSpace(string(body)), "true"), nil
 }
 
 // verifySHA256 checks that the file at path matches the expected hex digest.

--- a/notes/release.md
+++ b/notes/release.md
@@ -98,6 +98,7 @@ All objects live directly under the prefix — no `<tag>/` subdirectories. The `
 | `manifest-<tag>.json` | every tag | `immutable` | Per-tag asset listing |
 | `index.json` | every tag | `no-cache` | Full version catalogue |
 | `latest.json` | stable only | `no-cache` | Pointer to the latest stable manifest |
+| `windows-signed.txt` | stable only | `no-cache` | Code-signing gate for the latest Windows installer — see [§ Windows installer signing gate](#windows-installer-signing-gate) |
 
 Other assets (AAR, sdist, HTP cert/to-sign zips) ship via GitHub Releases / Maven Central / PyPI (stable) / TestPyPI (prerelease) only — not via S3.
 
@@ -165,3 +166,9 @@ The S3 bundle must contain exactly these eight files at the zip root: `libggml-h
 2. Submit for Microsoft signing.
 3. Upload the result to `s3://qaihub-public-assets/llama-cpp/libggml-htp-<sha>.zip`.
 4. Re-run the Release workflow for the same tag.
+
+## Windows installer signing gate
+
+The Windows installer is published before it is Authenticode-signed, so `geniex update` gates on `windows-signed.txt` to avoid pushing an unsigned build. On Windows, once a newer version is found, the updater GETs this file (see [`cli/cmd/geniex/update.go`](../cli/cmd/geniex/update.go), `isWindowsSigned`): contents `true` → proceed with the download; anything else or missing → treat as up-to-date and skip.
+
+Release-side: upload `windows-signed.txt` with `true` after the latest stable installer is signed; set it back to a non-`true` value before publishing the next, not-yet-signed installer.


### PR DESCRIPTION
## Summary

The Windows CLI installer is published to S3 before it is Authenticode-signed. `geniex update` now checks a `windows-signed.txt` flag on S3 (Windows only) and withholds the update until it reads `true`, so users are never offered an unsigned build.

- Add `windowsSignedURL` and `isWindowsSigned()` — GET `windows-signed.txt`, signed only when the body trims to `true`.
- In `runUpdate`, after the Windows guard and before fetching the manifest: if not signed, print `Already up-to-date.` and return (treated as no update).
- Document the gate in `notes/release.md` (§ S3 mirror layout + § Windows installer signing gate).

## Test plan

- [x] `bazelisk build //cli` passes.
- [ ] On Windows with a newer stable release, `windows-signed.txt` = `true` → update downloads and launches the installer.
- [x] Same, but flag absent or not `true` → `geniex update` reports up-to-date and downloads nothing.
- [x] Non-Windows platforms are unaffected (Linux install-script path, others error as before).