### PR TITLE
feat(sdk): honor HF_ENDPOINT for HuggingFace downloads

### DIFF
--- a/sdk/model-manager/crates/core/src/config.rs
+++ b/sdk/model-manager/crates/core/src/config.rs
@@ -37,6 +37,13 @@ impl StoreConfig {
         std::env::var("GENIEX_HFTOKEN").ok()
     }
 
+    pub fn hf_endpoint() -> String {
+        match std::env::var("HF_ENDPOINT") {
+            Ok(v) if !v.trim().is_empty() => v.trim().trim_end_matches('/').to_string(),
+            _ => crate::source::hf::DEFAULT_HF_ENDPOINT.to_string(),
+        }
+    }
+
     /// AI Hub public assets base URL. Mirrors the Go CLI's
     /// `DefaultAIHubBaseURL`; override via `GENIEX_AIHUBBASEURL`.
     pub fn ai_hub_base_url() -> String {
@@ -80,4 +87,57 @@ fn default_data_dir() -> PathBuf {
         .or_else(|_| std::env::var("USERPROFILE"))
         .unwrap_or_else(|_| ".".to_string());
     PathBuf::from(home).join(".cache").join("geniex")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::source::hf::DEFAULT_HF_ENDPOINT;
+
+    struct EnvGuard {
+        key: &'static str,
+        prev: Option<String>,
+    }
+
+    impl EnvGuard {
+        fn set(key: &'static str, value: &str) -> Self {
+            let prev = std::env::var(key).ok();
+            std::env::set_var(key, value);
+            Self { key, prev }
+        }
+        fn unset(key: &'static str) -> Self {
+            let prev = std::env::var(key).ok();
+            std::env::remove_var(key);
+            Self { key, prev }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match &self.prev {
+                Some(v) => std::env::set_var(self.key, v),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+
+    #[test]
+    fn hf_endpoint_covers_unset_custom_and_trailing_slash() {
+        {
+            let _g = EnvGuard::unset("HF_ENDPOINT");
+            assert_eq!(StoreConfig::hf_endpoint(), DEFAULT_HF_ENDPOINT);
+        }
+        {
+            let _g = EnvGuard::set("HF_ENDPOINT", "https://hf-mirror.com");
+            assert_eq!(StoreConfig::hf_endpoint(), "https://hf-mirror.com");
+        }
+        {
+            let _g = EnvGuard::set("HF_ENDPOINT", "https://hf-mirror.com/");
+            assert_eq!(StoreConfig::hf_endpoint(), "https://hf-mirror.com");
+        }
+        {
+            let _g = EnvGuard::set("HF_ENDPOINT", "  ");
+            assert_eq!(StoreConfig::hf_endpoint(), DEFAULT_HF_ENDPOINT);
+        }
+    }
 }

--- a/sdk/model-manager/crates/core/src/pull.rs
+++ b/sdk/model-manager/crates/core/src/pull.rs
@@ -214,9 +214,10 @@ pub(crate) fn build_source(
 ) -> Result<Box<dyn ModelSource>> {
     match &req.intent {
         PullIntent::HuggingFace { repo, token } => {
+            let endpoint = StoreConfig::hf_endpoint();
             let src = HfSource::with_endpoint_and_transport(
                 repo.clone(),
-                crate::source::hf::DEFAULT_HF_ENDPOINT,
+                &endpoint,
                 token.clone(),
                 transport,
                 req.hint.clone(),

--- a/sdk/model-manager/crates/core/src/source/hf.rs
+++ b/sdk/model-manager/crates/core/src/source/hf.rs
@@ -37,7 +37,8 @@ pub struct HfSource {
 impl HfSource {
     pub fn new(repo: String, token: Option<String>, hint: ManifestHint) -> Result<Self> {
         let transport: Arc<dyn HttpTransport> = Arc::new(ReqwestTransport::new()?);
-        Self::with_endpoint_and_transport(repo, DEFAULT_HF_ENDPOINT, token, transport, hint)
+        let endpoint = crate::config::StoreConfig::hf_endpoint();
+        Self::with_endpoint_and_transport(repo, &endpoint, token, transport, hint)
     }
 
     /// Escape hatch for tests / alternate endpoints / shared transports.


### PR DESCRIPTION
## Summary

Read the standard `HF_ENDPOINT` environment variable in the model-manager's HuggingFace pull path so users on networks where `huggingface.co` is unreachable (mainland China, etc.) can point downloads at a mirror such as `https://hf-mirror.com`. Matches the convention shared by `huggingface_hub`, the `hf` CLI, and every other HF-aware tool.

- New helper `StoreConfig::hf_endpoint()` — reads `HF_ENDPOINT`, falls back to `https://huggingface.co`, treats empty/whitespace as unset, trims trailing `/` for `url::Url::join` stability.
- Wired through the only production HF construction site (`build_source` in `pull.rs`) and `HfSource::new`.
- No FFI or public-header change; Go CLI, Python binding, C, and Android JNI inherit the fix.

Closes #1059.

## Test plan

- [x] `HF_ENDPOINT=https://hf-mirror.com cargo test --test hf_live -- --ignored` — `end_to_end_pull_via_hf` (tiny-llamas) and `end_to_end_pull_qwen3_q4_0` pull end-to-end from the mirror. Third live test (`gpt_oss_20b_mxfp4`) fails identically on `main` — pre-existing quant-casing assertion, unrelated to this change.
- [x] `cargo test -p model-manager-core config::` — new `hf_endpoint_covers_unset_custom_and_trailing_slash` covers unset / custom / trailing-slash / whitespace-only.
- [x] `cargo test -p model-manager-core source::hf` — existing wiremock plan tests still green (regression).