### PR TITLE
fix(server): unblock cross-origin browser clients in CORS middleware

### DIFF
--- a/cli/server/middleware/cors.go
+++ b/cli/server/middleware/cors.go
@@ -13,8 +13,7 @@ func CORS(c *gin.Context) {
 	h := c.Writer.Header()
 	h.Set("Access-Control-Allow-Origin", config.Get().Origins)
 	h.Set("Access-Control-Allow-Methods", "OPTIONS, GET, POST")
-	h.Set("Access-Control-Allow-Headers", "Content-Type, GenieX-KeepCache")
-	h.Set("Access-Control-Allow-Credentials", "true")
+	h.Set("Access-Control-Allow-Headers", "Authorization, Content-Type, GenieX-KeepCache")
 	h.Set("Access-Control-Max-Age", "86400")
 
 	if c.Request.Method == "OPTIONS" {


### PR DESCRIPTION
## Problem

`geniex serve` was unreachable from any cross-origin web page (Open WebUI, hosted OpenAI-compatible frontends), while the built-in Swagger UI and non-browser clients (Python, curl) worked fine.

## Cause

Two issues in `cli/server/middleware/cors.go`:

1. The middleware sent `Access-Control-Allow-Credentials: true` together with the default wildcard `Access-Control-Allow-Origin: *`. The Fetch spec forbids that combination, so browsers rejected every cross-origin response. Same-origin and non-browser clients don't run CORS checks, which is exactly the split reported in the issue.
2. `Access-Control-Allow-Headers` was missing `Authorization`, so any UI sending `Authorization: Bearer <key>` would fail preflight even with the wildcard fixed.

## Fix

Minimal change, as suggested by @mengshengwu in the issue thread:

- Drop the `Access-Control-Allow-Credentials` header — the server has no cookie-based auth, so nothing relied on it.
- Add `Authorization` to `Access-Control-Allow-Headers`.

## Testing

- `go build`, `go vet`, and `go test` on `cli/server/middleware` all pass.

Fixes #1168