### PR TITLE
chore(sdk): bump pinned aihub release to v0.58.0

### DIFF
--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -11,14 +11,6 @@ import (
 	"github.com/spf13/viper"
 )
 
-// DefaultAIHubBaseURL is the public root for Qualcomm AI Hub release assets.
-const DefaultAIHubBaseURL = "https://qaihub-public-assets.s3.us-west-2.amazonaws.com/qai-hub-models"
-
-// DefaultAIHubVersion is the pinned aihm release the CLI consumes. The public
-// bucket has no `latest` alias; manifests are only at
-// <base>/releases/<version>/manifest.json. Override via GENIEX_AIHUBVERSION.
-const DefaultAIHubVersion = "v0.57.0"
-
 type Config struct {
 	// Global settings
 	DataDir string
@@ -39,17 +31,15 @@ type Config struct {
 	KeyFile  string // TLS private key file path
 
 	// Env only params
-	HFToken      string
-	Log          string
-	AIHubVersion string // Override the pinned aihm release version
+	HFToken string
+	Log     string
 }
 
 // init sets up viper defaults and env binding. Runs once at package load.
 func init() {
 	// ENV only param need to set default here
-	viper.SetDefault("hftoken", "")                       // Default empty token
-	viper.SetDefault("log", "none")                       // Default log level
-	viper.SetDefault("aihubversion", DefaultAIHubVersion) // Pinned aihm release version
+	viper.SetDefault("hftoken", "") // Default empty token
+	viper.SetDefault("log", "none") // Default log level
 
 	viper.SetEnvPrefix("geniex")
 	viper.AutomaticEnv()

--- a/sdk/model-manager/crates/core/src/config.rs
+++ b/sdk/model-manager/crates/core/src/config.rs
@@ -73,7 +73,7 @@ const DEFAULT_AI_HUB_BASE_URL: &str =
     "https://qaihub-public-assets.s3.us-west-2.amazonaws.com/qai-hub-models";
 
 /// Mirrors `cli/internal/config/config.go:DefaultAIHubVersion`.
-const DEFAULT_AI_HUB_VERSION: &str = "v0.57.0";
+const DEFAULT_AI_HUB_VERSION: &str = "v0.58.0";
 
 fn default_data_dir() -> PathBuf {
     let home = std::env::var("HOME")

--- a/sdk/model-manager/crates/core/tests/ai_hub_live.rs
+++ b/sdk/model-manager/crates/core/tests/ai_hub_live.rs
@@ -28,7 +28,7 @@ use model_manager_core::transport::ReqwestTransport;
 
 const AI_HUB_BASE_URL: &str =
     "https://qaihub-public-assets.s3.us-west-2.amazonaws.com/qai-hub-models";
-const AI_HUB_VERSION: &str = "v0.57.0";
+const AI_HUB_VERSION: &str = "v0.58.0";
 
 const PHI_DISPLAY_NAME: &str = "Phi-3.5-Mini-Instruct";
 const PHI_CHIPSET: &str = "qualcomm-snapdragon-x-elite";


### PR DESCRIPTION
## What

- Bump the pinned aihm release from `v0.57.0` to `v0.58.0` (SDK `DEFAULT_AI_HUB_VERSION` + the live-test version pin).
- Drop the CLI-side aihub version config (constants, `Config.AIHubVersion` field, viper binding). The pinned release now lives solely in the SDK model-manager; the CLI no longer mirrors or forwards it.

## Why

`v0.58.0` is the first release whose **QCS8275 Genie zips are actually downloadable**. On `v0.57.0` the 8275 assets are listed in `release-assets.json` but the zip objects return `403` (the S3 bucket returns 403, not 404, for missing keys). Verified by HEAD-ing the actual download URLs:

| Model | chipset / runtime | v0.57.0 zip | v0.58.0 zip |
|---|---|---|---|
| `qwen3_8b` | qcs8275 / GENIE | ❌ 403 | ✅ 200, 4.26 GB |
| `qwen3_vl_4b_instruct` | qcs8275 / GENIE | ❌ 403 | ✅ 200, 2.83 GB |

Both are W4A16, Genie/QAIRT path. The qairt tool version is unchanged across the two releases (`2.45.0.260326154327`).

## Notes

- No FFI change (`geniex.h` untouched).
- The `third-party/llama.cpp` submodule shows a pre-existing dirty state unrelated to this change and is intentionally not included.