### PR TITLE
feat(sdk): auto-detect Snapdragon X2 Plus hosts

### DIFF
--- a/sdk/model-manager/crates/core/src/source/ai_hub/detect.rs
+++ b/sdk/model-manager/crates/core/src/source/ai_hub/detect.rs
@@ -10,9 +10,9 @@
 //! module takes a best-effort guess from the host.
 //!
 //! Current coverage:
-//!   * Windows on Snapdragon (X Elite / X Plus / X2 Elite) — parsed
-//!     from the CPU brand string via a `reg query` probe. This is the
-//!     95% case for Genie runtime users today.
+//!   * Windows on Snapdragon (X Elite / X Plus / X2 Elite / X2 Plus) —
+//!     parsed from the CPU brand string via a `reg query` probe. This
+//!     is the 95% case for Genie runtime users today.
 //!   * Linux on Qualcomm Dragonwing boards (QCS6490 / QCS9075) —
 //!     parsed from `/sys/firmware/devicetree/base/compatible`.
 //!   * Android on Snapdragon — parsed from the `ro.soc.model`
@@ -54,6 +54,10 @@ pub(crate) fn cpu_name_to_chipset_alias(brand: String) -> Option<String> {
         "X1E" => Some("qualcomm-snapdragon-x-elite".to_string()),
         "X1P" => Some("qualcomm-snapdragon-x-plus-8-core".to_string()),
         "X2E" => Some("qualcomm-snapdragon-x2-elite".to_string()),
+        // AI Hub publishes no dedicated X2 Plus bucket; the X2 Elite
+        // assets are the right ones — same Hexagon NPU generation
+        // (HTP v81), per maintainer guidance on issue #1223.
+        "X2P" => Some("qualcomm-snapdragon-x2-elite".to_string()),
         _ => None,
     }
 }
@@ -393,6 +397,17 @@ mod tests {
     #[test]
     fn parses_x2_elite_brand_string() {
         let brand = "Snapdragon X2 Elite - X2E80100 - Qualcomm Oryon CPU".to_string();
+        assert_eq!(
+            cpu_name_to_chipset_alias(brand).as_deref(),
+            Some("qualcomm-snapdragon-x2-elite")
+        );
+    }
+
+    #[test]
+    fn parses_x2_plus_brand_string() {
+        // X2 Plus has no dedicated AI Hub bucket; it must resolve to
+        // the X2 Elite assets (issue #1223).
+        let brand = "Snapdragon X2 Plus - X2P64100 - Qualcomm Oryon CPU".to_string();
         assert_eq!(
             cpu_name_to_chipset_alias(brand).as_deref(),
             Some("qualcomm-snapdragon-x2-elite")

--- a/sdk/model-manager/include/geniex_model.h
+++ b/sdk/model-manager/include/geniex_model.h
@@ -275,7 +275,7 @@ typedef struct {
      *
      * NULL or an empty string asks the SDK to auto-detect the host
      * chipset. Detection currently works on Windows-on-Snapdragon
-     * (X Elite / X Plus / X2 Elite); on other hosts an auto-detect
+     * (X Elite / X Plus / X2 Elite / X2 Plus); on other hosts an auto-detect
      * request fails with GENIEX_ERROR_COMMON_INVALID_INPUT and the
      * caller must pass a chipset explicitly.
      */
@@ -437,7 +437,7 @@ GENIEX_API void geniex_model_list_chipsets_free(geniex_ChipsetList* out);
 /**
  * @brief Detect the chipset of the current host.
  *
- * Probes the host (Windows-on-Snapdragon X Elite / X Plus / X2 Elite, Linux
+ * Probes the host (Windows-on-Snapdragon X Elite / X Plus / X2 Elite / X2 Plus, Linux
  * on Qualcomm Dragonwing boards QCS6490 / QCS9075, Android on Snapdragon via
  * `ro.soc.model`), then resolves the raw id to the AI Hub reference device
  * name (e.g. "Snapdragon X Elite CRD") — the same name geniex_model_list_chipsets


### PR DESCRIPTION
## Problem

Fixes #1223.

GenieX does not recognize retail **Snapdragon X2 Plus** devices. Windows chipset auto-detection ([`detect.rs`](https://github.com/qualcomm/GenieX/blob/main/sdk/model-manager/crates/core/src/source/ai_hub/detect.rs)) maps the Oryon SKU prefixes `X1E`, `X1P`, and `X2E` — but not `X2P` — so X2 Plus hosts fall through to `None` and users must configure the chipset manually:

```
geniex config set chipset "Snapdragon X2 Elite CRD"
```

## Fix

Map the `X2P` SKU prefix to `qualcomm-snapdragon-x2-elite`, mirroring @changzheng-zhang's recommended manual mapping in #1223. AI Hub's `platform.json` (checked live at `releases/v0.57.0`) publishes no dedicated X2 Plus bucket, and the X2 Elite entry (`sc8480xp`, `htp_version: 81`) carries the correct assets for the shared Hexagon NPU generation.

With this, on an X2 Plus machine the full flow works with zero manual configuration: brand-string probe -> `qualcomm-snapdragon-x2-elite` -> resolved against `platform.json` -> "Snapdragon X2 Elite CRD" assets pulled -> QAIRT / Hexagon NPU execution.

If AI Hub later publishes a dedicated `qualcomm-snapdragon-x2-plus` bucket, this one-line mapping is the only place to update.

## Testing

- New unit test `parses_x2_plus_brand_string` covering the X2P brand string, alongside the existing X1E/X1P/X2E cases.
- `cargo test -p model-manager-core -p model-manager-ffi` — all green (20/20 detect tests).
- `cargo fmt --check` clean.

Doc comments in `geniex_model.h` enumerating the auto-detected platforms updated to include X2 Plus.