### PR TITLE
docs(install): cross-link Docker and native Linux install paths

### DIFF
--- a/docs/cn/run/cli/install.mdx
+++ b/docs/cn/run/cli/install.mdx
@@ -40,7 +40,7 @@ CLI 提供 Windows ARM64 原生可执行文件，以及面向跃龙 QCS9075 等 
   </Tab>
 
   <Tab title="Linux ARM64 (Native)">
-    直接安装到跃龙 ARM64 Linux 主机（EVK、容器或任何带有高通 BSP 的设备）——无需 Docker。
+    直接在跃龙 ARM64 Linux 主机（EVK 或任何带有高通 BSP 的设备）上安装 `geniex`。若你更希望在容器中运行，请参见 [Linux (Docker) 安装](/cn/run/linux/install)。
 
     ### **前置条件**
 

--- a/docs/cn/run/linux/install.mdx
+++ b/docs/cn/run/linux/install.mdx
@@ -7,6 +7,10 @@ import Feedback from "/snippets/page-feedback.mdx";
 
 Linux Docker 路径通过 Linux ARM64 容器镜像运行，并支持 NPU 访问（适用于跃龙 QCS9075 等 IoT 平台）。
 
+<Note>
+  这是容器化路径。若你更希望在宿主机上直接安装 `geniex` 而不使用 Docker，请参见 [CLI 安装 → Linux ARM64 (Native)](/cn/run/cli/install)。
+</Note>
+
 ### **前置条件**
 
 - 安装了 Docker 的 Linux ARM64 主机——若尚未安装 Docker，请参照 [Docker 的 Ubuntu 安装指南](https://docs.docker.com/engine/install/ubuntu/)。

--- a/docs/en/run/cli/install.mdx
+++ b/docs/en/run/cli/install.mdx
@@ -40,7 +40,7 @@ The CLI ships as a native Windows ARM64 executable, and as a Linux ARM64 Docker 
   </Tab>
 
   <Tab title="Linux ARM64 (Native)">
-    Install directly on a Dragonwing ARM64 Linux host (EVK, container, or any device with a Qualcomm BSP) — no Docker required.
+    Install `geniex` directly on a Dragonwing ARM64 Linux host (EVK or any device with a Qualcomm BSP). If you'd rather run it inside a container, see [Linux (Docker) Install](/en/run/linux/install) instead.
 
     ### **Prerequisites**
 

--- a/docs/en/run/linux/install.mdx
+++ b/docs/en/run/linux/install.mdx
@@ -7,6 +7,10 @@ import Feedback from "/snippets/page-feedback.mdx";
 
 The Linux Docker path runs through a container image built for Linux ARM64 with NPU access (Dragonwing QCS9075 and similar IoT platforms).
 
+<Note>
+  This is the containerized path. If you'd rather install `geniex` directly on the host without Docker, see [CLI Install → Linux ARM64 (Native)](/en/run/cli/install).
+</Note>
+
 ### **Prerequisites**
 
 - Linux ARM64 host with Docker installed — if you don't have Docker yet, follow [Docker's Ubuntu install guide](https://docs.docker.com/engine/install/ubuntu/).


### PR DESCRIPTION
## Summary

The Linux (Docker) Install page listed Docker as a prerequisite, while the CLI Install → Linux ARM64 (Native) tab opened with \"no Docker required\". Neither page mentioned the other, so the two read as contradictions instead of two mutually exclusive paths.

Both pages now open with a one-line pointer to the other (EN + CN), so it's clear that Docker vs. native is a choice, not a conflict.

## Test plan

- [x] `docs/en/run/linux/install.mdx` and `docs/cn/run/linux/install.mdx` render the new `<Note>` block above `### Prerequisites`
- [x] Cross-links resolve (`/en/run/cli/install` ↔ `/en/run/linux/install`, and the CN equivalents)