### PR TITLE
fix(ci): verify HTP bundle is WHQL-signed before overlaying

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,13 +131,33 @@ jobs:
           set -euo pipefail
           sha=$(git -C third-party/llama.cpp rev-parse --short=6 HEAD)
           url="https://qaihub-public-assets.s3.us-west-2.amazonaws.com/llama-cpp/libggml-htp-${sha}.zip"
-          if curl -fsSL -o htp-signed.zip "$url"; then
-            unzip -o htp-signed.zip -d sdk-windows-arm64/lib/llama_cpp/
-            signed=true
-          else
-            signed=false
+          signed=false
+          # Stage and verify before touching the SDK: Windows only loads HTP
+          # skels whose catalog carries the Microsoft WHQL signature, so a
+          # wrong object in the bucket (e.g. the pre-WHQL submission zip,
+          # signed by Qualcomm's own cert) must not silently replace the
+          # self-signed build and ship as a "signed" release (#1220).
+          if curl -fsSL -o htp-signed.zip "$url" && unzip -o htp-signed.zip -d htp-staged/; then
+            cat=htp-staged/libggml-htp.cat
+            whql="CN=Microsoft Windows Hardware Compatibility Publisher"
+            if [[ ! -f "$cat" ]] || ! ls htp-staged/libggml-htp-v*.so >/dev/null 2>&1; then
+              echo "::warning::HTP bundle @ ${sha} lacks the catalog or skels; keeping self-signed build."
+            else
+              signer=$(openssl pkcs7 -inform DER -print_certs -in "$cat" | grep 'subject=' || true)
+              if ! grep -qF "$whql" <<<"$signer"; then
+                echo "::warning::HTP catalog @ ${sha} is not WHQL-signed; keeping self-signed build. Signer(s): ${signer}"
+              else
+                # The driver package needs the .inf alongside catalog + skels;
+                # restore it from the submodule when the bundle omits it.
+                if [[ ! -f htp-staged/libggml-htp.inf ]]; then
+                  cp third-party/llama.cpp/ggml/src/ggml-hexagon/libggml-htp.inf htp-staged/
+                fi
+                cp htp-staged/* sdk-windows-arm64/lib/llama_cpp/
+                signed=true
+              fi
+            fi
           fi
-          rm -f htp-signed.zip
+          rm -rf htp-signed.zip htp-staged
           echo "Signed HTP bundle for llama.cpp @ ${sha}: ${signed}"
           echo "signed=${signed}" >> "$GITHUB_OUTPUT"
           echo "llama_sha=${sha}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Problem

Related: #1220.

The `overlay-htp` release job trusts any object it finds at `llama-cpp/libggml-htp-<sha>.zip`: a successful `curl` is unzipped straight over the SDK and reported as `signed=true`, with no check of what was actually downloaded.

I compared the shipped artifacts to confirm this is what bit v0.3.16:

| | `libggml-htp.cat` signer | `libggml-htp.inf` |
|---|---|---|
| v0.3.14 (works) | `CN=Microsoft Windows Hardware Compatibility Publisher` (WHQL) | shipped |
| v0.3.16 (crashes) | `CN=QUALCOMM Inc.` via DigiCert only — the pre-WHQL submission signature | **missing** |

Windows only loads HTP skels whose catalog carries the Microsoft WHQL signature, so the Hexagon backend gets no device and every `llama_cpp` call aborts with `GGML_ASSERT(device)` — while the release still shipped without the `-selfsigned` suffix, defeating the existing gate.

This PR doesn't replace the corrected build the team is preparing — it fixes the pipeline defect so a wrong bucket object can't ship as a "signed" release again.

## Fix

Stage the bundle in a temp dir and verify before overlaying:

- `libggml-htp.cat` and at least one `libggml-htp-v*.so` are present;
- the catalog's PKCS#7 signer chain includes `CN=Microsoft Windows Hardware Compatibility Publisher` — checked with `openssl pkcs7 -print_certs`, available on the ubuntu runner;
- `libggml-htp.inf` is restored from the llama.cpp submodule (already checked out in this job) when the bundle omits it.

On any failure the job warns and keeps the self-signed build, so the artifact gets the `-selfsigned` suffix and the documented stable-tag gate in `notes/release.md` catches it before publish.

## Testing

- Ran the exact verification block against the real shipped catalogs: v0.3.14 → **ACCEPT** (WHQL-signed); v0.3.16 → **REJECT** (`signer: DigiCert / QUALCOMM Inc.`).
- Workflow YAML validated with PyYAML.