### PR TITLE
chore(release): source signed HTP bundle from qcom-ai-hub/geniex LFS

### DIFF
--- a/.github/scripts/release.js
+++ b/.github/scripts/release.js
@@ -34,7 +34,7 @@ module.exports = async ({ github, context, core }) => {
   const htpNote =
     HTP_SIGNED === "true"
       ? `## Hexagon HTP\n\nMicrosoft-signed HTP catalog (llama.cpp @ \`${LLAMA_SHA}\`). No cert import required on Windows on Snapdragon.`
-      : `## Hexagon HTP\n\nSelf-signed HTP catalog (llama.cpp @ \`${LLAMA_SHA}\`). End users must enable test signing and import \`ggml-htp-v1.cer\` per [notes/run.md](../blob/${VERSION}/notes/run.md).\n\nOperators: ship \`libggml-htp-to-sign-${LLAMA_SHA}.zip\` to the signing pipeline, then upload the signed result as \`libggml-htp-${LLAMA_SHA}.zip\` to \`s3://qaihub-public-assets/llama-cpp/\` and re-run this release.`;
+      : `## Hexagon HTP\n\nSelf-signed HTP catalog (llama.cpp @ \`${LLAMA_SHA}\`). End users must enable test signing and import \`ggml-htp-v1.cer\` per [notes/run.md](../blob/${VERSION}/notes/run.md).\n\nOperators: ship \`libggml-htp-to-sign-${LLAMA_SHA}.zip\` to the signing pipeline, then commit the signed result as \`sdk/signed-htp/libggml-htp-${LLAMA_SHA}.zip\` to \`qcom-ai-hub/geniex\` via PR (LFS-tracked) and re-run this release.`;
 
   let release;
   for await (const res of github.paginate.iterator(
@@ -46,7 +46,7 @@ module.exports = async ({ github, context, core }) => {
   }
 
   // Merge htpNote into the release body, replacing any stale HTP section from a
-  // prior run (e.g. self-signed → Microsoft-signed once the S3 bundle lands).
+  // prior run (e.g. self-signed → Microsoft-signed once the signed bundle lands).
   const mergeHtpNote = (body) => {
     const base = (body || "").replace(/## Hexagon HTP[\s\S]*$/m, "").trimEnd();
     return base ? `${base}\n\n${htpNote}` : htpNote;

--- a/.github/scripts/release.js
+++ b/.github/scripts/release.js
@@ -34,7 +34,7 @@ module.exports = async ({ github, context, core }) => {
   const htpNote =
     HTP_SIGNED === "true"
       ? `## Hexagon HTP\n\nMicrosoft-signed HTP catalog (llama.cpp @ \`${LLAMA_SHA}\`). No cert import required on Windows on Snapdragon.`
-      : `## Hexagon HTP\n\nSelf-signed HTP catalog (llama.cpp @ \`${LLAMA_SHA}\`). End users must enable test signing and import \`ggml-htp-v1.cer\` per [notes/run.md](../blob/${VERSION}/notes/run.md).\n\nOperators: ship \`libggml-htp-to-sign-${LLAMA_SHA}.zip\` to the signing pipeline, then commit the signed result as \`sdk/signed-htp/libggml-htp-${LLAMA_SHA}.zip\` to \`qcom-ai-hub/geniex\` via PR (LFS-tracked) and re-run this release.`;
+      : `## Hexagon HTP\n\nSelf-signed HTP catalog (llama.cpp @ \`${LLAMA_SHA}\`). End users: import \`ggml-htp-v1.cer\` per [notes/run.md](../blob/${VERSION}/notes/run.md). Operators: promote per [notes/release.md § Hexagon HTP signing](../blob/${VERSION}/notes/release.md#hexagon-htp-signing).`;
 
   let release;
   for await (const res of github.paginate.iterator(

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,8 +101,9 @@ jobs:
       version_tag: ${{ needs.resolve-tag.outputs.tag }}
       upload_artifact: true
 
-  # Overlay the Microsoft-signed HTP bundle from S3 if available; otherwise
-  # the Windows SDK stays self-signed and gets marked as such downstream.
+  # Overlay the Microsoft-signed HTP bundle from qcom-ai-hub/geniex LFS if
+  # available; otherwise the Windows SDK stays self-signed and gets marked
+  # as such downstream.
   overlay-htp:
     name: overlay-htp (windows-arm64)
     runs-on: ubuntu-latest
@@ -120,24 +121,35 @@ jobs:
       - name: Init llama.cpp submodule
         run: git submodule update --init --depth=1 third-party/llama.cpp
 
+      - name: Fetch signed HTP archive from qcom-ai-hub/geniex
+        uses: actions/checkout@v7
+        with:
+          repository: qcom-ai-hub/geniex
+          ref: main
+          lfs: true
+          path: signed-htp-src
+          sparse-checkout: sdk/signed-htp
+          sparse-checkout-cone-mode: false
+          token: ${{ secrets.QCOM_AI_HUB_GENIEX_READ_TOKEN }}
+          fetch-depth: 1
+
       - uses: actions/download-artifact@v8
         with:
           name: sdk-windows-arm64
           path: sdk-windows-arm64
 
-      - name: Overlay Microsoft-signed HTP bundle from S3 (if available)
+      - name: Overlay Microsoft-signed HTP bundle from LFS (if available)
         id: htp
         run: |
           set -euo pipefail
           sha=$(git -C third-party/llama.cpp rev-parse --short=6 HEAD)
-          url="https://qaihub-public-assets.s3.us-west-2.amazonaws.com/llama-cpp/libggml-htp-${sha}.zip"
-          if curl -fsSL -o htp-signed.zip "$url"; then
-            unzip -o htp-signed.zip -d sdk-windows-arm64/lib/llama_cpp/
+          src="signed-htp-src/sdk/signed-htp/libggml-htp-${sha}.zip"
+          if [[ -f "$src" ]]; then
+            unzip -o "$src" -d sdk-windows-arm64/lib/llama_cpp/
             signed=true
           else
             signed=false
           fi
-          rm -f htp-signed.zip
           echo "Signed HTP bundle for llama.cpp @ ${sha}: ${signed}"
           echo "signed=${signed}" >> "$GITHUB_OUTPUT"
           echo "llama_sha=${sha}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,7 +125,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           repository: qcom-ai-hub/geniex
-          ref: main
+          ref: chore/signed-htp-lfs-store
           lfs: false
           path: signed-htp-src
           sparse-checkout: sdk/signed-htp

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,15 +121,16 @@ jobs:
       - name: Init llama.cpp submodule
         run: git submodule update --init --depth=1 third-party/llama.cpp
 
-      - name: Fetch signed HTP archive from qcom-ai-hub/geniex
+      - name: Fetch signed HTP index from qcom-ai-hub/geniex
         uses: actions/checkout@v7
         with:
           repository: qcom-ai-hub/geniex
           ref: main
-          lfs: true
+          lfs: false
           path: signed-htp-src
           sparse-checkout: sdk/signed-htp
           sparse-checkout-cone-mode: false
+          persist-credentials: false
           token: ${{ secrets.GH_PAT }}
           fetch-depth: 1
 
@@ -140,11 +141,17 @@ jobs:
 
       - name: Overlay Microsoft-signed HTP bundle from LFS (if available)
         id: htp
+        env:
+          GH_PAT: ${{ secrets.GH_PAT }}
         run: |
           set -euo pipefail
           sha=$(git -C third-party/llama.cpp rev-parse --short=6 HEAD)
           src="signed-htp-src/sdk/signed-htp/libggml-htp-${sha}.zip"
           if [[ -f "$src" ]]; then
+            git -C signed-htp-src remote set-url origin \
+              "https://x-access-token:${GH_PAT}@github.com/qcom-ai-hub/geniex.git"
+            git -C signed-htp-src lfs install --local
+            git -C signed-htp-src lfs pull --include "sdk/signed-htp/libggml-htp-${sha}.zip"
             unzip -o "$src" -d sdk-windows-arm64/lib/llama_cpp/
             signed=true
           else

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,7 +130,7 @@ jobs:
           path: signed-htp-src
           sparse-checkout: sdk/signed-htp
           sparse-checkout-cone-mode: false
-          token: ${{ secrets.QCOM_AI_HUB_GENIEX_READ_TOKEN }}
+          token: ${{ secrets.GH_PAT }}
           fetch-depth: 1
 
       - uses: actions/download-artifact@v8

--- a/notes/release.md
+++ b/notes/release.md
@@ -172,7 +172,7 @@ The Windows ARM64 SDK ships `libggml-htp.cat` plus `libggml-htp-v{68,69,73,75,79
 
 The signed bundle must contain exactly these eight files at the zip root: `libggml-htp.cat`, `libggml-htp.inf`, and `libggml-htp-v{68,69,73,75,79,81}.so`.
 
-The cross-repo checkout uses `secrets.QCOM_AI_HUB_GENIEX_READ_TOKEN` — a GitHub App / fine-grained PAT scoped to `qcom-ai-hub/geniex` with `contents: read` + `metadata: read`. If CI reports `signed=false` but the bundle is merged on `main`, first check that this secret has not expired.
+The cross-repo checkout reuses `secrets.GH_PAT` (already scoped for cross-repo access to `qcom-ai-hub/geniex` — see `publish-s3` below). If CI reports `signed=false` but the bundle is merged on `main`, first check that `GH_PAT` has not expired.
 
 ### Promoting self-signed → Microsoft-signed
 

--- a/notes/release.md
+++ b/notes/release.md
@@ -165,14 +165,14 @@ The per-tag manifest is byte-stable across workflow re-runs of the same tag — 
 
 ## Hexagon HTP signing
 
-The Windows ARM64 SDK ships `libggml-htp.cat` plus `libggml-htp-v{68,69,73,75,79,81}.so` — Windows refuses to load them unsigned. Release CI runs an `overlay-htp` job **before** `build-cli` that sparse-checks-out `sdk/signed-htp/libggml-htp-<sha>.zip` from `qcom-ai-hub/geniex` (LFS-tracked), where `<sha>` is the `third-party/llama.cpp` short SHA. Both the installer and the SDK zip end up with the same HTP files:
+The Windows ARM64 SDK ships `libggml-htp.cat` plus `libggml-htp-v{68,69,73,75,79,81}.so` — Windows refuses to load them unsigned. Release CI runs an `overlay-htp` job **before** `build-cli` that sparse-checks-out `sdk/signed-htp/libggml-htp-<sha>.zip` from the `chore/signed-htp-lfs-store` branch of `qcom-ai-hub/geniex` (LFS-tracked), where `<sha>` is the `third-party/llama.cpp` short SHA. Both the installer and the SDK zip end up with the same HTP files:
 
 - **Hit** — overlay the Microsoft-signed files into the SDK artifact; `build-cli` packages them into the installer; release normally.
 - **Miss** — keep the self-signed build. The SDK name gets a `-selfsigned` suffix, and the release also carries `ggml-htp-v1.cer` (users import it) and `libggml-htp-to-sign-<sha>.zip` (operators submit it for signing).
 
 The signed bundle must contain exactly these eight files at the zip root: `libggml-htp.cat`, `libggml-htp.inf`, and `libggml-htp-v{68,69,73,75,79,81}.so`.
 
-The cross-repo checkout reuses `secrets.GH_PAT` (already scoped for cross-repo access to `qcom-ai-hub/geniex` — see `publish-s3` below). If CI reports `signed=false` but the bundle is merged on `main`, first check that `GH_PAT` has not expired.
+The cross-repo checkout reuses `secrets.GH_PAT` (already scoped for cross-repo access to `qcom-ai-hub/geniex` — see `publish-s3` below). If CI reports `signed=false` but the bundle is on `chore/signed-htp-lfs-store`, first check that `GH_PAT` has not expired.
 
 ### Promoting self-signed → Microsoft-signed
 
@@ -182,7 +182,7 @@ The cross-repo checkout reuses `secrets.GH_PAT` (already scoped for cross-repo a
    b. Submit Jenkins pipeline, fill path with `\path\to\ATT`, other field use default or first param.
    c. Get signed files from `ATT\Glymur\01000\ExtractedDrivers`.
    d. Repack the signed files (without `.inf`) into a zip with the same layout at the root.
-3. Commit the result to `qcom-ai-hub/geniex` at `sdk/signed-htp/libggml-htp-<sha>.zip` — `git lfs install` locally, add the zip on a branch, open a PR titled per [CONTRIBUTING.md](../CONTRIBUTING.md) (for example `chore(release): add signed HTP bundle for llama.cpp <sha>`), and get a maintainer to squash-merge into `main`.
+3. Commit the result to `qcom-ai-hub/geniex` at `sdk/signed-htp/libggml-htp-<sha>.zip` on the `chore/signed-htp-lfs-store` branch — `git lfs install` locally, push the zip directly, or open a PR against that branch and squash-merge.
 4. Re-run the Release workflow for the same tag.
 
 ## Windows installer signing gate

--- a/notes/release.md
+++ b/notes/release.md
@@ -165,12 +165,14 @@ The per-tag manifest is byte-stable across workflow re-runs of the same tag — 
 
 ## Hexagon HTP signing
 
-The Windows ARM64 SDK ships `libggml-htp.cat` plus `libggml-htp-v{68,69,73,75,79,81}.so` — Windows refuses to load them unsigned. Release CI runs an `overlay-htp` job **before** `build-cli` that `curl`s `s3://qaihub-public-assets/llama-cpp/libggml-htp-<sha>.zip`, where `<sha>` is the `third-party/llama.cpp` short SHA. Both the installer and the SDK zip end up with the same HTP files:
+The Windows ARM64 SDK ships `libggml-htp.cat` plus `libggml-htp-v{68,69,73,75,79,81}.so` — Windows refuses to load them unsigned. Release CI runs an `overlay-htp` job **before** `build-cli` that sparse-checks-out `sdk/signed-htp/libggml-htp-<sha>.zip` from `qcom-ai-hub/geniex` (LFS-tracked), where `<sha>` is the `third-party/llama.cpp` short SHA. Both the installer and the SDK zip end up with the same HTP files:
 
 - **Hit** — overlay the Microsoft-signed files into the SDK artifact; `build-cli` packages them into the installer; release normally.
 - **Miss** — keep the self-signed build. The SDK name gets a `-selfsigned` suffix, and the release also carries `ggml-htp-v1.cer` (users import it) and `libggml-htp-to-sign-<sha>.zip` (operators submit it for signing).
 
-The S3 bundle must contain exactly these eight files at the zip root: `libggml-htp.cat`, `libggml-htp.inf`, and `libggml-htp-v{68,69,73,75,79,81}.so`.
+The signed bundle must contain exactly these eight files at the zip root: `libggml-htp.cat`, `libggml-htp.inf`, and `libggml-htp-v{68,69,73,75,79,81}.so`.
+
+The cross-repo checkout uses `secrets.QCOM_AI_HUB_GENIEX_READ_TOKEN` — a GitHub App / fine-grained PAT scoped to `qcom-ai-hub/geniex` with `contents: read` + `metadata: read`. If CI reports `signed=false` but the bundle is merged on `main`, first check that this secret has not expired.
 
 ### Promoting self-signed → Microsoft-signed
 
@@ -178,9 +180,9 @@ The S3 bundle must contain exactly these eight files at the zip root: `libggml-h
 2. Submit for Microsoft signing.
    a. Put the `.cat` `.inf` and all `.so` files into `ATT\libggml-htp\` in samba;
    b. Submit Jenkins pipeline, fill path with `\path\to\ATT`, other field use default or first param.
-   c. Get singed files from `ATT\Glymur\01000\ExtractedDrivers`.
-   d. keep files in a zip with the same files (without `.inf`) at the root.
-3. Upload the result to `s3://qaihub-public-assets/llama-cpp/libggml-htp-<sha>.zip`, with public acl.
+   c. Get signed files from `ATT\Glymur\01000\ExtractedDrivers`.
+   d. Repack the signed files (without `.inf`) into a zip with the same layout at the root.
+3. Commit the result to `qcom-ai-hub/geniex` at `sdk/signed-htp/libggml-htp-<sha>.zip` — `git lfs install` locally, add the zip on a branch, open a PR titled per [CONTRIBUTING.md](../CONTRIBUTING.md) (for example `chore(release): add signed HTP bundle for llama.cpp <sha>`), and get a maintainer to squash-merge into `main`.
 4. Re-run the Release workflow for the same tag.
 
 ## Windows installer signing gate


### PR DESCRIPTION
## Summary

`overlay-htp` in [.github/workflows/release.yml](.github/workflows/release.yml) now sparse-checks-out `sdk/signed-htp/libggml-htp-<sha>.zip` from the `chore/signed-htp-lfs-store` branch of [`qcom-ai-hub/geniex`](https://github.com/qcom-ai-hub/geniex/tree/chore/signed-htp-lfs-store) (LFS-tracked, reusing `secrets.GH_PAT`) instead of `curl`ing S3. Signed bundles land via ordinary push into that branch.

[notes/release.md § Hexagon HTP signing](notes/release.md) and the self-signed fragment in [.github/scripts/release.js](.github/scripts/release.js) are rewritten. Miss semantics unchanged: no bundle for the current llama.cpp short SHA → `-selfsigned` SDK zip + `libggml-htp-to-sign-<sha>.zip` in the release.

## Test plan

- [x] Miss path: `v0.3.18-alpha.1` → `Signed HTP bundle for llama.cpp @ ae9291: false`; release assets include `-selfsigned` SDK zip, `ggml-htp-v1.cer`, `libggml-htp-to-sign-ae9291.zip`.
- [x] Hit path (mechanics): `v0.3.18-alpha.3` with a placeholder zip on `chore/signed-htp-lfs-store` → `signed=true`; `git lfs pull --include` materialized only the target zip; SDK zip has **no** `-selfsigned` suffix and **no** to-sign / `.cer` assets.
- [x] Hit path (parity): `v0.3.18-alpha.4` after mirroring the production `libggml-htp-ae9291.zip` from S3 into LFS → the six `libggml-htp*` files inside `geniex-sdk-windows-arm64-v0.3.18-alpha.4.zip` are **byte-identical** (sha256) to `geniex-sdk-windows-arm64-v0.3.17.zip`. Confirms the new LFS-sourced pipeline produces the same artifact as the old S3-sourced one.
- [x] Narrow checkout: sparse (`sdk/signed-htp`) + `lfs: false` at checkout + `git lfs pull --include <exact path>` — verified in alpha.3 / alpha.4 logs.
- [x] Credentials: `persist-credentials: false` clears the zizmor "credential persistence" finding.