### PR TITLE
fix(sdk): forward quant suffix on benchmark cache hit

### DIFF
--- a/sdk/benchmark/benchmark.c
+++ b/sdk/benchmark/benchmark.c
@@ -413,7 +413,7 @@ static int resolve_via_mm(options_t* o, const char* id_in) {
      * second cell of a matrix. Fall through to pull on file-not-found. */
     geniex_ModelPaths paths;
     memset(&paths, 0, sizeof(paths));
-    int32_t rc = geniex_model_get_paths(name, &paths);
+    int32_t rc = geniex_model_get_paths(id_in, &paths);
     if (rc != GENIEX_SUCCESS) {
         geniex_ModelPullInput in;
         memset(&in, 0, sizeof(in));
@@ -431,7 +431,7 @@ static int resolve_via_mm(options_t* o, const char* id_in) {
             free(buf);
             return 1;
         }
-        rc = geniex_model_get_paths(name, &paths);
+        rc = geniex_model_get_paths(id_in, &paths);
         if (rc != GENIEX_SUCCESS) {
             const char* m = geniex_model_last_error_message();
             fprintf(stderr, "ERROR: geniex_model_get_paths(%s): %s (%d)\n", id_in, m ? m : "?", rc);


### PR DESCRIPTION
## Summary

`geniex-bench`'s model-manager id path silently ignored the `:quant` suffix once a repo was cached: every `org/repo:Q4_0` / `:Q8_0` / `:Q4_K_M` resolved to whichever gguf was cached first, so a matrix of quants all measured the same file (#1236).

`resolve_via_mm()` splits the id into `name` + `quant` via `split_id()`, but the cache-hit fast path called `geniex_model_get_paths(name, ...)` with the suffix already stripped. `geniex_model_get_paths` *is* quant-aware — it re-splits `org/repo:quant` internally (`store.rs` `split_quant`, covered by `test_model_manager.c:178/182`) — it just needs the full id. The fix passes `id_in` (suffix intact) at both call sites. `split_id`'s `name`/`quant` are still used for the cache-miss `geniex_model_pull` branch.

## Test plan

Reproduced and verified against a locally-cached multi-quant repo `unsloth/Qwen3.5-0.8B-GGUF` (Q4_0 + Q8_0 cached), reading the `[mm] resolved … -> …` line which is emitted before model load:

- [x] **Before:** `:Q4_0`, `:Q8_0`, `:Q4_K_M` all resolved to `Qwen3.5-0.8B-Q4_0.gguf`
- [x] **After:** `:Q4_0` → `Q4_0.gguf`, `:Q8_0` → `Q8_0.gguf` (each quant selects its own file)
- [x] **After:** `:Q4_K_M` (not downloaded) now reports `quantization 'Q4_K_M' … not downloaded` and correctly falls through to pull, instead of silently returning Q4_0
- [x] `geniex-bench` rebuilds clean (`cmake --build build --target geniex-bench`)

Not an FFI change — no public header touched.

Closes #1236