### PR TITLE
fix(sdk): pin CPU runs to an explicit empty device list

### DIFF
--- a/sdk/plugins/llama_cpp/include/params.h
+++ b/sdk/plugins/llama_cpp/include/params.h
@@ -21,7 +21,13 @@ namespace geniex {
 // share the same upstream tuning.
 enum class Device { CPU, GPU, NPU };
 
-std::optional<std::vector<ggml_backend_dev_t>> resolve_devices(const char* device_id);
+// Resolve a comma-separated device_id list to ggml devices for
+// llama_model_params::devices. Returns nullopt when names were given but none
+// resolved. An empty vector means "no explicit selection" and the caller
+// leaves llama.cpp's default device list in place — except for CPU runs,
+// which get an explicit empty (null-terminated) list so llama.cpp never
+// initializes GPU backends the run won't use.
+std::optional<std::vector<ggml_backend_dev_t>> resolve_devices(const char* device_id, Device device);
 
 // Reverse-classify a resolved device selection. Mirrors the alias table in
 // sdk/src/device.cpp:

--- a/sdk/plugins/llama_cpp/src/llm.cpp
+++ b/sdk/plugins/llama_cpp/src/llm.cpp
@@ -61,7 +61,7 @@ int32_t LlamaLlm::create(const geniex_LlmCreateInput* input) {
         }
     }
 
-    auto selection = resolve_devices(input->device_id);
+    auto selection = resolve_devices(input->device_id, device);
     if (!selection) {
         return GENIEX_ERROR_COMMON_INVALID_INPUT;
     }

--- a/sdk/plugins/llama_cpp/src/params.cpp
+++ b/sdk/plugins/llama_cpp/src/params.cpp
@@ -175,10 +175,19 @@ common_params_sampling build_sampling_params(const geniex_SamplerConfig* cfg) {
     return s;
 }
 
-std::optional<std::vector<ggml_backend_dev_t>> resolve_devices(const char* device_id) {
+std::optional<std::vector<ggml_backend_dev_t>> resolve_devices(const char* device_id, Device device) {
     std::vector<ggml_backend_dev_t> devices;
     if (!device_id || device_id[0] == '\0') {
-        return devices;  // empty: caller uses the model default
+        // A null llama_model_params::devices makes llama.cpp claim every
+        // registered GPU-type device, initializing backends the run never
+        // uses. For CPU runs that is fatal on Adreno GPUs with pre-3.0
+        // OpenCL drivers (SD 888 / 8 Gen 1): ggml-opencl registers the
+        // device but kernel compilation aborts the process (#1235). Pin
+        // CPU runs to an explicit empty list; hybrid keeps the default.
+        if (device == Device::CPU) {
+            devices.push_back(nullptr);  // list with only the terminator
+        }
+        return devices;
     }
 
     const std::string device_str(device_id);

--- a/sdk/plugins/llama_cpp/src/vlm.cpp
+++ b/sdk/plugins/llama_cpp/src/vlm.cpp
@@ -43,7 +43,7 @@ int32_t LlamaVlm::create(const geniex_VlmCreateInput* input) {
     const geniex_ModelConfig& config = input->config;
 
     llama_model_params mpar      = build_model_params(config, device);
-    auto               selection = resolve_devices(input->device_id);
+    auto               selection = resolve_devices(input->device_id, device);
     if (!selection) {
         return GENIEX_ERROR_COMMON_INVALID_INPUT;
     }


### PR DESCRIPTION
Fixes #1235

## Root cause

On Qualcomm devices the crash reported in #1235 is not an OpenCL version *requirement* — it is llama.cpp's default device selection.

When the `cpu` alias is used, `geniex_resolve_device` correctly produces `device_id = NULL` + `n_gpu_layers = 0`, but the llama_cpp plugin then leaves `llama_model_params::devices` null (`resolve_devices` returns an empty vector for a null id). A null `devices` list makes llama.cpp claim **every registered GPU-type device** (`llama_prepare_model_devices` in `src/llama.cpp`), and `llama_init_from_model` creates a backend for each of them regardless of `n_gpu_layers`.

On Snapdragon 888 / 8 Gen 1 the Adreno 660/730 driver passes ggml-opencl's registration gate (OpenCL C 2.0 + fp16), so the device registers fine — but backend init then hard-aborts: `ggml_cl_init` uses fatal `CL_CHECK`s and `load_cl_kernels` calls `build_program_from_source(..., fatal=true)`, which `exit(1)`s when the older Adreno compiler rejects any of the ~200 kernels. The whole process dies even though the user asked for CPU.

This also explains why non-Qualcomm chips are unaffected: `clGetPlatformIDs` finds no platform there, zero OpenCL devices register, and the CPU path never touches the backend.

## Fix

For CPU runs with no explicit device selection, pass a device list containing only the null terminator instead of leaving `devices` null. llama.cpp then resolves zero offload devices and runs pure CPU without ever initializing the OpenCL (or Hexagon) backend.

- `cpu` alias → explicit empty list; GPU backends never initialized (the crash in #1235)
- explicit `GPUOpenCL` / `HTP0` selections → unchanged
- `hybrid` (empty device_id, ngl ≠ 0) → unchanged, keeps llama.cpp's default HTP+CPU scheduling path
- third-party/llama.cpp untouched

Applied to both `LlamaLlm::create` and `LlamaVlm::create` via the shared `resolve_devices` helper.

## Testing

- Model-free pytest shard (`pytest tests -m api`) is covered by CI; the device matrix runs on QDC via pr-check.
- No public header (`geniex.h`) or alias-table change, so no FFI/bindings update is required.
