### PR TITLE
chore(sdk): drop stale gitattributes and gitmodules

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-. filter=lfs diff=lfs merge=lfs -text

--- a/sdk/.gitattributes
+++ b/sdk/.gitattributes
@@ -1,5 +1,0 @@
-plugins/qnn/libs/** filter=lfs diff=lfs merge=lfs -text
-libs/** filter=lfs diff=lfs merge=lfs -text
-*.dll filter=lfs diff=lfs merge=lfs -text
-*.lib filter=lfs diff=lfs merge=lfs -text
-*.so filter=lfs diff=lfs merge=lfs -text

--- a/sdk/.gitmodules
+++ b/sdk/.gitmodules
@@ -1,6 +1,0 @@
-[submodule "third-party/jni"]
-	path = third-party/jni
-	url = ../../android/ndk
-[submodule "third-party/llama.cpp"]
-	path = third-party/llama.cpp
-	url = ../llama.cpp-for-sdk.git


### PR DESCRIPTION
## Summary

Three git-metadata files in the tree are dead configuration and get removed:

- `sdk/.gitmodules` — declares submodules at `sdk/third-party/jni` and `sdk/third-party/llama.cpp`. `sdk/third-party/` does not exist; the active submodules (`third-party/llama.cpp`, `third-party/geniex-qairt`) are registered in the repo-root `.gitmodules`. Carried over by the GenieX-bridge squash-import.
- `sdk/.gitattributes` — declares LFS filters for `plugins/qnn/libs/**`, `libs/**`, and `*.dll/*.lib/*.so`. None of those paths exist under `sdk/`, and no `.dll/.lib/.so` are tracked in `sdk/`. Same origin.
- `.gitattributes` (repo root) — single line `. filter=lfs diff=lfs merge=lfs -text`. The pattern `.` matches nothing (`git check-attr filter -- <any-source>` reports `unspecified`), so it has no effect.

Confirmed still-active git-metadata files are untouched: repo-root `.gitmodules`, `sdk/patches/.gitattributes`, `tests/cli/.gitattributes`.

## Test plan

- [x] `git check-attr filter -- sdk/CMakeLists.txt sdk/src/device.cpp` reports `unspecified` — nothing was silently pulled from the deleted attribute files.
- [x] `git submodule status` lists exactly `third-party/llama.cpp` and `third-party/geniex-qairt`.
- [x] `git lfs ls-files` still lists the three `tests/cli/assets/` LFS entries — the `tests/cli/.gitattributes` pattern is unaffected.