### PR TITLE
feat(sdk): expose raw logits (geniex_llm_forward_logits) in bench + serve

### DIFF
--- a/bindings/go/llm.go
+++ b/bindings/go/llm.go
@@ -268,6 +268,78 @@ func (l *LLM) GetModelInfo() (LlmModelInfo, error) {
 	}, nil
 }
 
+// ForwardLogitsResult holds one prefill-only forward pass. Logits is row-major
+// [NRows, RowWidth]. When TopN is 0, RowWidth == VocabSize and TokenIDs is nil
+// (column index is the token id). When TopN > 0, RowWidth == min(TopN, VocabSize),
+// each row holds its top logits sorted descending, and TokenIDs is the matching
+// [NRows, RowWidth] token ids.
+type ForwardLogitsResult struct {
+	Logits    []float32
+	TokenIDs  []int32
+	NRows     int
+	RowWidth  int
+	VocabSize int
+}
+
+// ForwardLogits runs a single non-autoregressive forward pass over inputIDs.
+// When allPositions is false NRows is 1 (the last token's row); when true it is
+// len(inputIDs). topN > 0 reduces each row to its top-N logits (with matching
+// token ids); topN == 0 returns the full vocabulary per row. The caller owns any
+// special tokens; none are added.
+func (l *LLM) ForwardLogits(inputIDs []int32, allPositions bool, topN int) (ForwardLogitsResult, error) {
+	if l.ptr == nil {
+		return ForwardLogitsResult{}, SDKError(-1)
+	}
+	if len(inputIDs) == 0 {
+		return ForwardLogitsResult{}, SDKError(-100001) // GENIEX_ERROR_COMMON_INVALID_INPUT
+	}
+
+	n := len(inputIDs)
+	raw := cMalloc(C.size_t(n) * C.size_t(unsafe.Sizeof(C.int32_t(0))))
+	defer C.free(raw)
+	ids := unsafe.Slice((*C.int32_t)(raw), n)
+	for i, id := range inputIDs {
+		ids[i] = C.int32_t(id)
+	}
+
+	cInput := C.geniex_LlmForwardLogitsInput{
+		input_ids:       (*C.int32_t)(raw),
+		input_ids_count: C.int32_t(n),
+		all_positions:   C.bool(allPositions),
+		top_n:           C.int32_t(topN),
+	}
+
+	var cOutput C.geniex_LlmForwardLogitsOutput
+	res := C.geniex_llm_forward_logits(l.ptr, &cInput, &cOutput)
+	if res < 0 {
+		return ForwardLogitsResult{}, SDKError(res)
+	}
+	defer C.geniex_free(unsafe.Pointer(cOutput.logits))
+	defer C.geniex_free(unsafe.Pointer(cOutput.token_ids))
+
+	out := ForwardLogitsResult{
+		NRows:     int(cOutput.n_rows),
+		RowWidth:  int(cOutput.row_width),
+		VocabSize: int(cOutput.vocab_size),
+	}
+	total := out.NRows * out.RowWidth
+	if total > 0 && cOutput.logits != nil {
+		out.Logits = make([]float32, total)
+		src := unsafe.Slice((*C.float)(cOutput.logits), total)
+		for i := 0; i < total; i++ {
+			out.Logits[i] = float32(src[i])
+		}
+	}
+	if total > 0 && cOutput.token_ids != nil {
+		out.TokenIDs = make([]int32, total)
+		src := unsafe.Slice((*C.int32_t)(cOutput.token_ids), total)
+		for i := 0; i < total; i++ {
+			out.TokenIDs[i] = int32(src[i])
+		}
+	}
+	return out, nil
+}
+
 type LlmSaveKVCacheInput struct {
 	Path string
 }

--- a/bindings/python/geniex/_ffi/_api.py
+++ b/bindings/python/geniex/_ffi/_api.py
@@ -21,6 +21,8 @@ from ._types import (
     geniex_LlmApplyChatTemplateInput,
     geniex_LlmApplyChatTemplateOutput,
     geniex_LlmCreateInput,
+    geniex_LlmForwardLogitsInput,
+    geniex_LlmForwardLogitsOutput,
     geniex_LlmGenerateInput,
     geniex_LlmGenerateOutput,
     geniex_LlmModelInfo,
@@ -183,6 +185,13 @@ def _bind_all() -> None:
 
     lib.geniex_llm_get_model_info.argtypes = [c_void_p, POINTER(geniex_LlmModelInfo)]
     lib.geniex_llm_get_model_info.restype = c_int32
+
+    lib.geniex_llm_forward_logits.argtypes = [
+        c_void_p,
+        POINTER(geniex_LlmForwardLogitsInput),
+        POINTER(geniex_LlmForwardLogitsOutput),
+    ]
+    lib.geniex_llm_forward_logits.restype = c_int32
 
     lib.geniex_llm_apply_chat_template.argtypes = [
         c_void_p,

--- a/bindings/python/geniex/_ffi/_types.py
+++ b/bindings/python/geniex/_ffi/_types.py
@@ -183,6 +183,25 @@ class geniex_LlmModelInfo(Structure):
     ]
 
 
+class geniex_LlmForwardLogitsInput(Structure):
+    _fields_ = [
+        ('input_ids', POINTER(c_int32)),
+        ('input_ids_count', c_int32),
+        ('all_positions', c_bool),
+        ('top_n', c_int32),  # 0: full vocab per row. >0: keep only the top-N logits per row.
+    ]
+
+
+class geniex_LlmForwardLogitsOutput(Structure):
+    _fields_ = [
+        ('logits', POINTER(c_float)),  # caller frees with geniex_free
+        ('token_ids', POINTER(c_int32)),  # NULL when top_n == 0; else [n_rows, row_width]; caller frees
+        ('n_rows', c_int32),
+        ('row_width', c_int32),  # top_n > 0 ? min(top_n, vocab_size) : vocab_size
+        ('vocab_size', c_int32),
+    ]
+
+
 class geniex_LlmChatMessage(Structure):
     _fields_ = [
         ('role', c_char_p),

--- a/bindings/python/geniex/modeling.py
+++ b/bindings/python/geniex/modeling.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import os
-from ctypes import POINTER, byref, c_char_p, c_void_p, cast, pointer, string_at
+from ctypes import POINTER, byref, c_char_p, c_int32, c_void_p, cast, pointer, string_at
 
 from ._ffi._api import GENIEX_ERROR_LLM_TOKENIZATION_CONTEXT_LENGTH, _check, _str_list_to_c, load_library
 from ._ffi._types import (
@@ -16,6 +16,8 @@ from ._ffi._types import (
     geniex_LlmApplyChatTemplateInput,
     geniex_LlmApplyChatTemplateOutput,
     geniex_LlmChatMessage,
+    geniex_LlmForwardLogitsInput,
+    geniex_LlmForwardLogitsOutput,
     geniex_LlmGenerateInput,
     geniex_LlmGenerateOutput,
     geniex_SamplerConfig,
@@ -292,6 +294,52 @@ class GenieXLLM:
         """Clear KV cache and reset sampler state."""
         lib = load_library()
         _check(lib.geniex_llm_reset(self._handle))
+
+    def forward_logits(
+        self, input_ids: list[int], *, all_positions: bool = False, top_n: int = 0
+    ) -> list[list[float]] | list[list[tuple[int, float]]]:
+        """Run a single forward pass over ``input_ids`` and return raw logits.
+
+        With ``all_positions=False`` (default) there is one row (the last
+        token's logits); with ``all_positions=True`` there is one row per input
+        token. ``top_n=0`` (default) returns each row as ``vocab_size`` floats
+        (column index is the token id). ``top_n>0`` returns each row as a list
+        of ``(token_id, logit)`` pairs sorted by descending logit. The caller
+        owns any special tokens; none are added. Intended for on-target accuracy
+        metrics (perplexity, MMLU, MMMU).
+        """
+        if not input_ids:
+            raise ValueError('input_ids must be non-empty')
+        if top_n < 0:
+            raise ValueError('top_n must be >= 0')
+        lib = load_library()
+
+        n = len(input_ids)
+        IdArray = c_int32 * n
+        ids = IdArray(*[int(t) for t in input_ids])
+        inp = geniex_LlmForwardLogitsInput(
+            input_ids=cast(ids, POINTER(c_int32)),
+            input_ids_count=n,
+            all_positions=all_positions,
+            top_n=top_n,
+        )
+        out = geniex_LlmForwardLogitsOutput()
+        _check(lib.geniex_llm_forward_logits(self._handle, byref(inp), byref(out)))
+
+        n_rows = int(out.n_rows)
+        row_width = int(out.row_width)
+        try:
+            flat = out.logits[: n_rows * row_width]
+            rows_logits = [flat[r * row_width : (r + 1) * row_width] for r in range(n_rows)]
+            if not out.token_ids:
+                return rows_logits
+            flat_ids = out.token_ids[: n_rows * row_width]
+            return [list(zip(flat_ids[r * row_width : (r + 1) * row_width], rows_logits[r])) for r in range(n_rows)]
+        finally:
+            if out.logits:
+                lib.geniex_free(cast(out.logits, c_void_p))
+            if out.token_ids:
+                lib.geniex_free(cast(out.token_ids, c_void_p))
 
     def save_kv_cache(self, path: str) -> None:
         """Save the current KV cache to ``path``."""

--- a/cli/server/docs/swagger.yaml
+++ b/cli/server/docs/swagger.yaml
@@ -25,6 +25,30 @@ paths:
               schema:
                 $ref: "#/components/schemas/ChatCompletionResponse"
 
+  /v1/logits:
+    post:
+      summary: Raw logits from a single prefill-only forward pass
+      description: |
+        Runs one non-autoregressive forward pass over pre-tokenized input and
+        returns the raw LM-head logits. This is NOT the OpenAI generative
+        logprobs semantics — no sampling or decode loop runs. Intended for
+        on-target accuracy metrics (perplexity, MMLU, MMMU). Input is
+        pre-tokenized (`input_ids`); the server does not tokenize text here.
+      operationId: PostV1Logits
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ForwardLogitsRequest"
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ForwardLogitsResponse"
+
   /v1/models:
     get:
       summary: Lists the currently available models
@@ -66,6 +90,64 @@ paths:
 
 components:
   schemas:
+    # ---------- Logits ----------
+    ForwardLogitsRequest:
+      type: object
+      required: [model, input_ids]
+      example:
+        model: "qualcomm/Qwen3-4B-Instruct-2507"
+        input_ids: [1, 2, 3, 4]
+        last_only: false
+        top_n: 20
+      properties:
+        model:
+          type: string
+        input_ids:
+          type: array
+          items:
+            type: integer
+          description: Pre-tokenized token ids; the caller owns any special tokens.
+        last_only:
+          type: boolean
+          description: "false (default): every position. true: last token's row only."
+        top_n:
+          type: integer
+          description: "Keep only the top-N logits per row (default 20). 0 returns the full vocabulary per row."
+        nctx:
+          type: integer
+        ngl:
+          type: integer
+        compute:
+          type: string
+    ForwardLogitsResponse:
+      type: object
+      properties:
+        model:
+          type: string
+        n_rows:
+          type: integer
+        vocab_size:
+          type: integer
+        top_n:
+          type: integer
+          description: Effective top-N used (0 means full vocabulary per row).
+        rows:
+          type: array
+          description: One entry per emitted position.
+          items:
+            type: object
+            properties:
+              token_ids:
+                type: array
+                items:
+                  type: integer
+                description: Token id per logit; omitted when top_n is 0 (column index is the token id).
+              logits:
+                type: array
+                items:
+                  type: number
+                description: top_n > 0 — top logits sorted descending; top_n == 0 — full vocab in token-id order.
+
     # ---------- Chat ----------
     ChatCompletionRequest:
       type: object

--- a/cli/server/handler/BUILD.bazel
+++ b/cli/server/handler/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     name = "handler",
     srcs = [
         "chat.go",
+        "logits.go",
         "model.go",
     ],
     importpath = "github.com/qualcomm/GenieX/cli/server/handler",

--- a/cli/server/handler/logits.go
+++ b/cli/server/handler/logits.go
@@ -1,0 +1,140 @@
+// Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
+package handler
+
+import (
+	"log/slog"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	geniex_sdk "github.com/qualcomm/GenieX/bindings/go"
+	"github.com/qualcomm/GenieX/cli/internal/config"
+	"github.com/qualcomm/GenieX/cli/server/service"
+)
+
+// ForwardLogitsRequest is the body for POST /v1/logits.
+//
+// This is a prefill-only forward pass (raw logits), not the OpenAI generative
+// logprobs semantics: the model runs one non-autoregressive pass over the input
+// and returns the raw LM-head logits. Input is pre-tokenized (InputIDs); the
+// server has no public tokenizer to accept text here.
+type ForwardLogitsRequest struct {
+	Model    string  `json:"model"`
+	InputIDs []int32 `json:"input_ids"`
+	// LastOnly emits only the last token's logits row (next-token / MMLU
+	// scoring); the default (false) emits every position's row for perplexity.
+	LastOnly bool `json:"last_only"`
+	// TopN keeps only the top-N logits per row (the SDK does the reduction).
+	// nil / omitted defaults to 20; an explicit 0 returns the full vocabulary.
+	TopN *int `json:"top_n"`
+
+	// Compute-unit / layer overrides, same semantics as chat completions.
+	NCtx    int32  `json:"nctx"`
+	Ngl     int32  `json:"ngl"`
+	Compute string `json:"compute"`
+}
+
+const defaultLogitsTopN = 20
+
+// ForwardLogitsResponse carries the per-position rows. Each row is top-N
+// [token_id, logit] pairs sorted by descending logit (like geniex-bench). When
+// top_n is 0 each row is the full vocabulary, ordered by token id, and token id
+// is the column index — TokenIDs is then omitted.
+type ForwardLogitsResponse struct {
+	Model     string        `json:"model"`
+	NRows     int           `json:"n_rows"`
+	VocabSize int           `json:"vocab_size"`
+	TopN      int           `json:"top_n"`
+	Rows      []ForwardRow  `json:"rows"`
+}
+
+// ForwardRow is one position's logits. For top-N output, Logits[i] pairs with
+// TokenIDs[i]. For full-vocab output, TokenIDs is nil and the index is the token.
+type ForwardRow struct {
+	TokenIDs []int32   `json:"token_ids,omitempty"`
+	Logits   []float32 `json:"logits"`
+}
+
+func ForwardLogits(c *gin.Context) {
+	cfg := config.Get()
+	req := ForwardLogitsRequest{NCtx: cfg.NCtx, Ngl: cfg.Ngl, Compute: cfg.Compute}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		slog.Error("Failed to bind JSON", "error", err)
+		c.JSON(http.StatusBadRequest, map[string]any{"error": err.Error()})
+		return
+	}
+	if len(req.InputIDs) == 0 {
+		c.JSON(http.StatusBadRequest, map[string]any{"error": "input_ids must be non-empty"})
+		return
+	}
+
+	name, _ := geniex_sdk.SplitNamePrecision(req.Model)
+	modelType, err := geniex_sdk.ModelGetType(name)
+	if err != nil {
+		slog.Error("Failed to get model type", "model", req.Model, "error", err)
+		c.JSON(http.StatusBadRequest, map[string]any{"error": err.Error()})
+		return
+	}
+	if modelType != geniex_sdk.ModelTypeLLM {
+		c.JSON(http.StatusBadRequest, map[string]any{"error": "logits is only supported for LLM models"})
+		return
+	}
+	paths, err := geniex_sdk.ModelGetPaths(name)
+	if err != nil {
+		slog.Error("Failed to resolve model paths", "model", req.Model, "error", err)
+		c.JSON(http.StatusBadRequest, map[string]any{"error": err.Error()})
+		return
+	}
+
+	modelParam, err := service.ResolveModelParam(paths.RuntimeID, paths.ModelName, req.NCtx, req.Ngl, req.Compute, service.SpecParam{})
+	if err != nil {
+		slog.Error("Failed to resolve model params", "model", req.Model, "error", err)
+		c.JSON(http.StatusBadRequest, map[string]any{"error": err.Error()})
+		return
+	}
+
+	p, err := service.KeepAliveGet[geniex_sdk.LLM](
+		req.Model,
+		modelParam,
+		c.GetHeader("GenieX-KeepCache") != "true",
+	)
+	if writeKeepAliveError(c, err) {
+		return
+	}
+
+	topN := defaultLogitsTopN
+	if req.TopN != nil {
+		if *req.TopN < 0 {
+			c.JSON(http.StatusBadRequest, map[string]any{"error": "top_n must be >= 0"})
+			return
+		}
+		topN = *req.TopN
+	}
+
+	res, err := p.ForwardLogits(req.InputIDs, !req.LastOnly, topN)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, map[string]any{"error": err.Error(), "code": geniex_sdk.SDKErrorCode(err)})
+		return
+	}
+
+	rows := make([]ForwardRow, res.NRows)
+	for r := 0; r < res.NRows; r++ {
+		lo := r * res.RowWidth
+		hi := lo + res.RowWidth
+		row := ForwardRow{Logits: res.Logits[lo:hi]}
+		if res.TokenIDs != nil {
+			row.TokenIDs = res.TokenIDs[lo:hi]
+		}
+		rows[r] = row
+	}
+
+	c.JSON(http.StatusOK, ForwardLogitsResponse{
+		Model:     req.Model,
+		NRows:     res.NRows,
+		VocabSize: res.VocabSize,
+		TopN:      topN,
+		Rows:      rows,
+	})
+}

--- a/cli/server/route.go
+++ b/cli/server/route.go
@@ -43,6 +43,9 @@ func RegisterAPIv1(r *gin.Engine) {
 	// ==== openai compatible ====
 	g.POST("/chat/completions", handler.ChatCompletions)
 
+	// ==== raw logits (prefill-only forward pass; not OpenAI generative logprobs) ====
+	g.POST("/logits", handler.ForwardLogits)
+
 	// ==== model management ====
 	g.GET("/models/*model", handler.RetrieveModel)
 	g.GET("/models", handler.ListModels)

--- a/notes/bench.md
+++ b/notes/bench.md
@@ -117,3 +117,43 @@ Expand-Archive bench.zip -DestinationPath .
 
 Each archive contains `bin/geniex-bench` (or `.exe`) plus `lib/` with all
 required runtime shared libraries (libgeniex, llama_cpp plugin, qairt plugin).
+
+### Raw logits mode (`--logits`)
+
+For on-target accuracy metrics (perplexity, MMLU, MMMU), `--logits` runs a
+single prefill-only forward pass (`geniex_llm_forward_logits`, no decode loop)
+over `-p N` random token ids and writes every position's logits row
+(`[n_tokens, vocab]`) to the JSON report. Bypasses the timing machinery
+entirely (`--warmup` / `-r` / `-n` are ignored).
+
+```bash
+geniex-bench --plugin llama_cpp --device npu -m <model> --logits -p 128 \
+  --logits-top-n 20 --output-json logits.json
+```
+
+The report keeps only the top-N `[token_id, logit]` pairs per row
+(`--logits-top-n`, default 20) so the all-positions output stays small; the JSON
+records `top_n` and `truncated_to_top_n` so a consumer never mistakes it for
+the full vocabulary. Input is random ids only — the forward-logits API takes
+`input_ids` and the bench tool has no tokenizer, so `--prompt-file` is rejected
+with `--logits`. Both `llama_cpp` and `qairt` backends support it.
+
+The JSON report (`schema_version` `logits-1`) carries shape metadata plus
+`rows`, one row per emitted position, each a top-N array of `[token_id, logit]`
+pairs sorted by descending logit:
+
+```json
+{
+  "schema_version": "logits-1",
+  "n_prompt": 128,
+  "all_positions": true,
+  "n_rows": 128,
+  "vocab_size": 151936,
+  "top_n": 20,
+  "truncated_to_top_n": true,
+  "rows": [
+    [[9, 6.950917], [1479, 6.472050], ...],
+    ...
+  ]
+}
+```

--- a/sdk/benchmark/README.md
+++ b/sdk/benchmark/README.md
@@ -122,6 +122,15 @@ geniex-bench \
   --plugin llama_cpp --device hybrid \
   -m .../Qwen3-1.7B-Q4_0.gguf \
   --accuracy --prompt-file prompt.txt -n 128
+
+# Logits mode: one prefill-only forward pass (no decode loop), write every
+# position's top-N logits to JSON for on-target accuracy metrics (perplexity,
+# MMLU, MMMU). Input is random ids only (-p N); add --logits-last-only for just
+# the last token's row.
+geniex-bench \
+  --plugin llama_cpp --device npu \
+  -m .../Qwen3-1.7B-Q4_0.gguf \
+  --logits -p 128 --logits-top-n 20 --output-json logits.json
 ```
 
 On Windows the same invocations work with `.exe` and backslash paths, e.g.:
@@ -142,6 +151,11 @@ Run `geniex-bench --help` for the full flag list.
   text to stdout (`[gen ] ...`); use it to sanity-check output quality rather
   than timing. Pair with `--prompt-file`, since the default random-ids prefill
   yields meaningless text.
+- `--logits` runs one prefill-only forward pass (no decode loop, no timing) over
+  `-p N` random ids and writes every position's top-N logits to `--output-json`
+  (`--logits-top-n`, default 20; `--logits-last-only` for the last row only).
+  Both llama_cpp and qairt support it; `--prompt-file` is rejected since the
+  forward-logits API takes `input_ids` and the tool has no tokenizer.
 - llama_cpp gets a `[warmup=i]` / `[run=i]` suffix appended to the prompt
   so the KV cache is busted between runs
 - for `--plugin qairt`, `prompt_tokens` and `prefill_tps` are reported over the
@@ -169,6 +183,44 @@ Run `geniex-bench --help` for the full flag list.
     "gen_tokens":  {"median": 128},
     "prompt_tokens":{"median": 42}
   }
+}
+```
+
+## Accuracy mode output
+
+`--accuracy` prints the generated text to stdout, one `[gen ]`-prefixed line
+per output line, then the usual `[ok  ]` summary line:
+
+```
+[gen ] The capital of France is Paris.
+[gen ] Answer: Paris
+[ok  ] cell  plugin=llama_cpp device=cpu ngl=0 ttft=475.6ms prefill=25.3tps decode=18.2tps gen=24 tok
+```
+
+## Logits mode JSON shape
+
+`--logits` writes its own report (`schema_version` `logits-1`): shape metadata
+plus `rows`, one row per emitted position, each a top-N array of
+`[token_id, logit]` pairs sorted by descending logit.
+
+```json
+{
+  "schema_version": "logits-1",
+  "cell_id": "cell",
+  "plugin": "llama_cpp",
+  "device": "npu",
+  "model_path": ".../Qwen3-1.7B-Q4_0.gguf",
+  "n_gpu_layers": 999,
+  "n_prompt": 128,
+  "all_positions": true,
+  "n_rows": 128,
+  "vocab_size": 151936,
+  "top_n": 20,
+  "truncated_to_top_n": true,
+  "rows": [
+    [[9, 6.950917], [1479, 6.472050], ...],
+    ...
+  ]
 }
 ```
 

--- a/sdk/benchmark/benchmark.c
+++ b/sdk/benchmark/benchmark.c
@@ -104,6 +104,12 @@ typedef struct {
     int32_t repeat;
     bool    reset_between_runs; /* true => geniex_llm_reset() before each run, freeing KV */
     bool    accuracy;           /* true => single run (warmup=0, repeat=1), print generated text */
+
+    /* Prefill-only raw-logits mode (--logits): one forward pass over the prompt,
+     * no decode loop. Bypasses the timing/warmup/repeat machinery entirely. */
+    bool    logits_mode;
+    bool    logits_last_only; /* default: every position; set to emit only the last token's row */
+    int32_t logits_top_n;     /* per row, emit only the top-N (token_id, logit) pairs */
     int32_t n_ctx;
     int32_t n_threads;
     int32_t ngl_override; /* -1 = use resolved alias default; >=0 overrides */
@@ -259,6 +265,21 @@ static void usage(const char* argv0) {
         "                         speed. Overrides --warmup / --repetitions. Pair\n"
         "                         with --prompt-file for a real prompt; the default\n"
         "                         random-ids prefill produces meaningless text.\n"
+        "  --logits               prefill-only raw-logits mode: run one forward pass\n"
+        "                         (geniex_llm_forward_logits, no decode loop) over N\n"
+        "                         random token ids (-p N, like the timing default) and\n"
+        "                         write every position's logits row ([n_tokens, vocab])\n"
+        "                         to the JSON report, for on-target accuracy metrics\n"
+        "                         (perplexity/MMLU/MMMU). Bypasses timing; --warmup/-r/-n\n"
+        "                         are ignored. Input is random ids only (the\n"
+        "                         forward-logits API takes input_ids, and the bench tool\n"
+        "                         has no tokenizer): --prompt-file is rejected with\n"
+        "                         --logits.\n"
+        "  --logits-last-only     with --logits, emit only the last token's logits row\n"
+        "                         instead of every position (next-token / MMLU scoring).\n"
+        "  --logits-top-n N       with --logits, emit only the top-N (token_id, logit)\n"
+        "                         pairs per row (default 20) to keep the JSON small;\n"
+        "                         the report records this truncation.\n"
         "\n"
         "Optional (multimodal):\n"
         "  --tokenizer-path PATH  explicit tokenizer file\n"
@@ -648,6 +669,9 @@ static void parse_args(int argc, char** argv, options_t* o) {
     o->repeat             = 5;
     o->reset_between_runs = true;
     o->accuracy           = false;
+    o->logits_mode        = false;
+    o->logits_last_only   = false;
+    o->logits_top_n       = 20;
     o->n_ctx              = 0;
     o->n_threads          = 0;
     o->ngl_override       = -1;
@@ -716,6 +740,13 @@ static void parse_args(int argc, char** argv, options_t* o) {
             o->reset_between_runs = false;
         } else if (strcmp(a, "--accuracy") == 0) {
             o->accuracy = true;
+        } else if (strcmp(a, "--logits") == 0) {
+            o->logits_mode = true;
+        } else if (strcmp(a, "--logits-last-only") == 0) {
+            o->logits_mode      = true;
+            o->logits_last_only = true;
+        } else if (strcmp(a, "--logits-top-n") == 0) {
+            o->logits_top_n = atoi(arg_value(argc, argv, &i, a));
         } else if (strcmp(a, "-c") == 0 || strcmp(a, "--ctx-size") == 0) {
             o->n_ctx = atoi(arg_value(argc, argv, &i, a));
         } else if (strcmp(a, "-t") == 0 || strcmp(a, "--threads") == 0) {
@@ -762,6 +793,17 @@ static void parse_args(int argc, char** argv, options_t* o) {
     if (o->accuracy) {
         o->warmup = 0;
         o->repeat = 1;
+    }
+
+    if (o->logits_mode) {
+        if (o->prompt_buf) {
+            fprintf(stderr, "ERROR: --logits uses random token ids; --prompt-file is not supported with it\n");
+            exit(2);
+        }
+        if (o->logits_top_n < 1) {
+            fprintf(stderr, "ERROR: --logits-top-n must be >=1\n");
+            exit(2);
+        }
     }
 
     if (o->matrix_file) {
@@ -1496,6 +1538,56 @@ static void write_json(const options_t* o, const char* device_id, int32_t ngl, i
     (void)json_field_dbl;
 }
 
+/* Write one row of the SDK's top-N output as a JSON array of [token_id, logit]
+ * pairs. The SDK already selected and sorted the top-N (descending logit), so
+ * this just formats row_width pairs. */
+static void write_top_n_row(FILE* f, const int32_t* ids, const float* logits, int32_t row_width) {
+    fputc('[', f);
+    for (int32_t k = 0; k < row_width; ++k) {
+        fprintf(f, "%s[%d, %.6f]", k ? ", " : "", ids[k], logits[k]);
+    }
+    fputc(']', f);
+}
+
+/* Write the prefill-only logits report for --logits. Emits shape metadata plus,
+ * per row, the top-N [token_id, logit] pairs. Records the top-N truncation
+ * explicitly so a consumer never mistakes it for the full vocabulary. */
+static void write_logits_json(const options_t* o, const char* device_id, int32_t ngl,
+    const geniex_LlmForwardLogitsInput* fin, const geniex_LlmForwardLogitsOutput* fout) {
+    FILE* f = fopen(o->output_json, "w");
+    if (!f) {
+        fprintf(stderr, "ERROR: cannot open %s for write\n", o->output_json);
+        exit(1);
+    }
+    const bool truncated = fout->row_width < fout->vocab_size;
+
+    fprintf(f, "{\n");
+    json_field_str(f, "schema_version", "logits-1", false);
+    json_field_str(f, "cell_id", o->cell_id ? o->cell_id : "cell", false);
+    json_field_str(f, "plugin", o->plugin, false);
+    json_field_str(f, "device", o->device, false);
+    json_field_str(f, "device_id", device_id, false);
+    json_field_str(f, "model_path", o->model_path, false);
+    json_field_i64(f, "n_gpu_layers", ngl, false);
+    json_field_i64(f, "n_prompt", fin->input_ids_count, false);
+    fprintf(f, "    \"all_positions\": %s,\n", fin->all_positions ? "true" : "false");
+    json_field_i64(f, "n_rows", fout->n_rows, false);
+    json_field_i64(f, "vocab_size", fout->vocab_size, false);
+    json_field_i64(f, "top_n", fout->row_width, false);
+    fprintf(f, "    \"truncated_to_top_n\": %s,\n", truncated ? "true" : "false");
+
+    fprintf(f, "    \"rows\": [\n");
+    for (int32_t r = 0; r < fout->n_rows; ++r) {
+        const size_t off = (size_t)r * fout->row_width;
+        fprintf(f, "      ");
+        write_top_n_row(f, fout->token_ids + off, fout->logits + off, fout->row_width);
+        fprintf(f, r + 1 < fout->n_rows ? ",\n" : "\n");
+    }
+    fprintf(f, "    ]\n");
+    fprintf(f, "}\n");
+    fclose(f);
+}
+
 /* Trim the `-{plugin}-{device}[-c{N}]` tail from a cell_id; falls back to the
  * raw id when the suffix isn't present. Caller frees. */
 static char* model_label(const char* cell_id, const char* plugin, const char* device) {
@@ -1591,6 +1683,93 @@ static void write_md_row(const options_t* o, int32_t ngl, int64_t model_size_byt
     fclose(f);
 }
 
+/* --logits mode: prefill-only raw logits, no timing. Runs one forward pass over
+ * `o->n_prompt` random token ids and writes the top-N (token_id, logit) pairs
+ * per row to `o->output_json`. Bypasses run_llm's warmup/repeat/aggregate path.
+ * The forward-logits API takes input_ids only, so this is random-ids input
+ * (bench has no tokenizer). */
+static void run_logits(const options_t* o, const char* device_id, int32_t ngl) {
+    geniex_LlmCreateInput cin;
+    memset(&cin, 0, sizeof(cin));
+    cin.model_name     = "benchmark";
+    cin.model_path     = o->model_path;
+    cin.tokenizer_path = o->tokenizer_path; /* may be NULL */
+    cin.plugin_id      = o->plugin;
+    cin.device_id      = device_id; /* may be NULL */
+    fill_model_config(&cin.config, o, ngl);
+
+    geniex_LLM* llm = NULL;
+    check(geniex_llm_create(&cin, &llm), "geniex_llm_create");
+
+    geniex_LlmModelInfo info;
+    int32_t             rc_info = geniex_llm_get_model_info(llm, &info);
+    if (rc_info != GENIEX_SUCCESS || info.vocab_size <= 0) {
+        const char* msg = geniex_get_error_message((geniex_ErrorCode)rc_info);
+        fprintf(stderr,
+            "ERROR: %s plugin does not support random-ids prefill required by --logits "
+            "(geniex_llm_get_model_info: %s, code=%d).\n",
+            o->plugin,
+            msg ? msg : "?",
+            rc_info);
+        geniex_llm_destroy(llm);
+        exit(1);
+    }
+
+    int32_t* tokens = (int32_t*)malloc((size_t)o->n_prompt * sizeof(int32_t));
+    if (!tokens) {
+        fprintf(stderr, "ERROR: oom allocating %d prompt tokens\n", o->n_prompt);
+        geniex_llm_destroy(llm);
+        exit(1);
+    }
+    srand((unsigned)o->seed);
+    for (int32_t k = 0; k < o->n_prompt; ++k) {
+        tokens[k] = (int32_t)(rand() % info.vocab_size);
+    }
+    if (info.add_bos && info.bos_token >= 0 && o->n_prompt > 0) {
+        tokens[0] = info.bos_token;
+    }
+
+    geniex_LlmForwardLogitsInput  fin;
+    geniex_LlmForwardLogitsOutput fout;
+    memset(&fin, 0, sizeof(fin));
+    memset(&fout, 0, sizeof(fout));
+    fin.input_ids       = tokens;
+    fin.input_ids_count = o->n_prompt;
+    fin.all_positions   = !o->logits_last_only;
+    fin.top_n           = o->logits_top_n;
+
+    int32_t rc = geniex_llm_forward_logits(llm, &fin, &fout);
+    if (rc != GENIEX_SUCCESS) {
+        const char* msg = geniex_get_error_message((geniex_ErrorCode)rc);
+        fprintf(stderr, "ERROR: geniex_llm_forward_logits failed: %s (%d)\n", msg ? msg : "?", rc);
+        free(tokens);
+        geniex_llm_destroy(llm);
+        exit(1);
+    }
+
+    fprintf(stdout,
+        "[ok  ] %s  plugin=%s device=%s ngl=%d logits n_rows=%d vocab=%d top_n=%d%s\n",
+        o->cell_id ? o->cell_id : "cell",
+        o->plugin,
+        o->device,
+        ngl,
+        fout.n_rows,
+        fout.vocab_size,
+        fout.row_width,
+        fout.row_width < fout.vocab_size ? " (rows truncated to top_n)" : "");
+
+    if (o->output_json) {
+        write_logits_json(o, device_id, ngl, &fin, &fout);
+    } else {
+        fprintf(stderr, "[warn] --logits without --output-json: logits computed but not written\n");
+    }
+
+    geniex_free(fout.logits);
+    geniex_free(fout.token_ids);
+    free(tokens);
+    geniex_llm_destroy(llm);
+}
+
 /* ----------------------------- main ----------------------------- */
 
 /* Run one (plugin, device, model) cell using the already-`geniex_init`'d
@@ -1652,6 +1831,37 @@ static int run_one_cell(options_t* o) {
         o->n_ctx = 0;
     }
 
+    bool is_vlm = (o->mmproj_path != NULL) || o->force_vlm;
+
+    /* --logits is a prefill-only forward pass, not a timing run: it skips the
+     * warmup/repeat/aggregate machinery and writes its own report. LLM only. */
+    if (o->logits_mode) {
+        if (is_vlm) {
+            fprintf(stderr, "ERROR: --logits is not supported for VLM models\n");
+            if (anchored) free(anchored);
+            if (rout.device_id) geniex_free(rout.device_id);
+            if (rout.warning) geniex_free(rout.warning);
+            return 1;
+        }
+        run_logits(o, device_id, ngl);
+        if (anchored) free(anchored);
+        if (rout.device_id) geniex_free(rout.device_id);
+        if (rout.warning) geniex_free(rout.warning);
+        if (o->mm_model_path) {
+            geniex_free(o->mm_model_path);
+            o->mm_model_path = NULL;
+        }
+        if (o->mm_mmproj) {
+            geniex_free(o->mm_mmproj);
+            o->mm_mmproj = NULL;
+        }
+        if (o->mm_tokenizer) {
+            geniex_free(o->mm_tokenizer);
+            o->mm_tokenizer = NULL;
+        }
+        return 0;
+    }
+
     run_result_t* runs = (run_result_t*)calloc((size_t)o->repeat, sizeof(run_result_t));
     if (!runs) {
         fprintf(stderr, "ERROR: oom\n");
@@ -1661,7 +1871,6 @@ static int run_one_cell(options_t* o) {
         return 1;
     }
 
-    bool is_vlm = (o->mmproj_path != NULL) || o->force_vlm;
     if (is_vlm) {
         run_vlm(o, device_id, ngl, runs);
     } else {

--- a/sdk/include/geniex.h
+++ b/sdk/include/geniex.h
@@ -620,6 +620,62 @@ typedef struct {
  */
 GENIEX_API int32_t geniex_llm_get_model_info(geniex_LLM* handle, geniex_LlmModelInfo* output);
 
+/* ====================  Forward Logits  =================================== */
+
+/** Input for a single non-autoregressive forward pass over pre-tokenized input.
+ *
+ * The caller owns any special tokens (BOS/EOS); none are added automatically,
+ * matching geniex_LlmGenerateInput's input_ids contract. */
+typedef struct {
+    const int32_t* input_ids;       /** Pre-tokenized token IDs (non-NULL). */
+    int32_t        input_ids_count; /** Token count (>= 1). */
+    bool           all_positions;   /** false: last token's row only. true: every position. */
+    int32_t        top_n;           /** 0: full vocab per row. >0: keep only the top-N logits per row. */
+} geniex_LlmForwardLogitsInput;
+
+/** Output of geniex_llm_forward_logits. Zero-initialized by the bridge before
+ *  the plugin populates it.
+ *
+ *  Row-major [n_rows, row_width]. When top_n == 0 the columns are the full
+ *  vocabulary (row_width == vocab_size) and token_ids is NULL — column index is
+ *  the token id. When top_n > 0 each row holds its top row_width logits sorted
+ *  descending, and token_ids[r * row_width + c] is the corresponding token id. */
+typedef struct {
+    float*   logits;     /** Caller frees with geniex_free. */
+    int32_t* token_ids;  /** NULL when top_n == 0; else [n_rows, row_width]; caller frees with geniex_free. */
+    int32_t  n_rows;     /** all_positions ? input_ids_count : 1. */
+    int32_t  row_width;  /** top_n > 0 ? min(top_n, vocab_size) : vocab_size. */
+    int32_t  vocab_size; /** Full vocabulary size, regardless of top_n. */
+} geniex_LlmForwardLogitsOutput;
+
+/**
+ * @brief Run a single forward pass and return raw logits (no sampling, no decode loop).
+ *
+ * Runs the prefill path against a fresh KV cache and reads the LM-head output
+ * directly, for on-target accuracy metrics (perplexity, MMLU, MMMU) that score
+ * logits rather than generate text. Does not disturb geniex_llm_generate's
+ * sampler/KV state. Not all plugins support this; those that don't return
+ * GENIEX_ERROR_COMMON_PARAM_NOT_SUPPORTED.
+ *
+ * With input->top_n > 0 the raw per-row logits are reduced to their top-N (by
+ * descending logit) before returning: output->logits and output->token_ids are
+ * both [n_rows, row_width] and row_width == min(top_n, vocab_size). This keeps
+ * all-positions output small (full vocab per row is hundreds of MB).
+ *
+ * @param handle[in]:  LLM handle.
+ * @param input[in]:   Pre-tokenized input and the all_positions flag.
+ * @param output[out]: Filled-in logits buffer (caller frees output->logits with geniex_free).
+ *
+ * @return geniex_ErrorCode:
+ *   - GENIEX_SUCCESS                              on success.
+ *   - GENIEX_ERROR_COMMON_NOT_INITIALIZED         when handle is NULL / model not ready.
+ *   - GENIEX_ERROR_COMMON_INVALID_INPUT           when input/output is NULL or input_ids is empty.
+ *   - GENIEX_ERROR_COMMON_PARAM_NOT_SUPPORTED     when the plugin cannot produce logits.
+ *   - GENIEX_ERROR_LLM_TOKENIZATION_CONTEXT_LENGTH when input_ids exceeds the max context length.
+ */
+GENIEX_API int32_t geniex_llm_forward_logits(
+    geniex_LLM* handle, const geniex_LlmForwardLogitsInput* input, geniex_LlmForwardLogitsOutput* output);
+
 /* ========================================================================== */
 /*                              MULTIMODAL MODELS (VLM)                          */
 /* ========================================================================== */

--- a/sdk/include/plugin/ILlm.h
+++ b/sdk/include/plugin/ILlm.h
@@ -35,6 +35,16 @@ class ILlm {
      * information keep building. Plugins able to report it MUST override.
      */
     virtual int32_t get_model_info(geniex_LlmModelInfo*) { return GENIEX_ERROR_COMMON_PARAM_NOT_SUPPORTED; }
+
+    /**
+     * @brief Run a single forward pass and return raw logits (no sampling/decode).
+     *
+     * Default returns PARAM_NOT_SUPPORTED so plugins that cannot expose logits
+     * keep building. Plugins able to produce them MUST override.
+     */
+    virtual int32_t forward_logits(const geniex_LlmForwardLogitsInput*, geniex_LlmForwardLogitsOutput*) {
+        return GENIEX_ERROR_COMMON_PARAM_NOT_SUPPORTED;
+    }
 };
 
 }  // namespace geniex

--- a/sdk/plugins/llama_cpp/include/llm.h
+++ b/sdk/plugins/llama_cpp/include/llm.h
@@ -58,6 +58,8 @@ class LlamaLlm : public ILlm {
 
     virtual int32_t get_model_info(geniex_LlmModelInfo*) override;
 
+    virtual int32_t forward_logits(const geniex_LlmForwardLogitsInput*, geniex_LlmForwardLogitsOutput*) override;
+
    private:
     void set_sampler(const geniex_SamplerConfig* cfg);
 

--- a/sdk/plugins/llama_cpp/src/llm.cpp
+++ b/sdk/plugins/llama_cpp/src/llm.cpp
@@ -4,6 +4,8 @@
 #include "llm.h"
 
 #include <algorithm>
+#include <cstdlib>
+#include <cstring>
 #include <fstream>
 #include <nlohmann/json.hpp>
 #include <sstream>
@@ -466,6 +468,87 @@ int32_t LlamaLlm::get_model_info(geniex_LlmModelInfo* output) {
     const llama_token bos    = llama_vocab_bos(vocab);
     output->bos_token        = (bos == LLAMA_TOKEN_NULL) ? -1 : static_cast<int32_t>(bos);
     output->add_bos          = llama_vocab_get_add_bos(vocab) ? 1 : 0;
+    return GENIEX_SUCCESS;
+}
+
+int32_t LlamaLlm::forward_logits(const geniex_LlmForwardLogitsInput* input, geniex_LlmForwardLogitsOutput* output) {
+    if (!this->ctx || !this->model) return GENIEX_ERROR_COMMON_NOT_INITIALIZED;
+    if (!input || !output) return GENIEX_ERROR_COMMON_INVALID_INPUT;
+    if (!input->input_ids || input->input_ids_count <= 0) return GENIEX_ERROR_COMMON_INVALID_INPUT;
+
+    const llama_vocab* vocab   = llama_model_get_vocab(this->model);
+    const int          n_vocab = llama_vocab_n_tokens(vocab);
+    const int          n_ctx   = llama_n_ctx(this->ctx);
+    const int          n_batch = llama_n_batch(this->ctx);
+    const int          n_tok   = input->input_ids_count;
+
+    for (int i = 0; i < n_tok; i++) {
+        if (input->input_ids[i] < 0 || input->input_ids[i] >= n_vocab) {
+            GENIEX_LOG_ERROR("forward_logits: token ID out of range: {}", input->input_ids[i]);
+            return GENIEX_ERROR_COMMON_INVALID_INPUT;
+        }
+    }
+    if (n_tok > n_ctx) {
+        GENIEX_LOG_WARN("forward_logits: input ({}) exceeds context length ({})", n_tok, n_ctx);
+        return GENIEX_ERROR_LLM_TOKENIZATION_CONTEXT_LENGTH;
+    }
+
+    // Fresh KV in, clean KV out: result depends only on input_ids and
+    // generate()'s prefix-cache/KV state is left undisturbed.
+    this->reset();
+
+    const bool         all_positions = input->all_positions;
+    std::vector<float> all_logits;
+    all_logits.reserve(static_cast<size_t>(all_positions ? n_tok : 1) * n_vocab);
+
+    int32_t     rc    = GENIEX_SUCCESS;
+    llama_batch batch = llama_batch_init(n_batch, 0, 1);
+    for (int start = 0; start < n_tok; start += n_batch) {
+        const int n    = std::min(n_batch, n_tok - start);
+        batch.n_tokens = n;
+        for (int j = 0; j < n; j++) {
+            const int abs_pos  = start + j;
+            batch.token[j]     = input->input_ids[abs_pos];
+            batch.pos[j]       = abs_pos;
+            batch.n_seq_id[j]  = 1;
+            batch.seq_id[j][0] = 0;
+            // Always emit the last token's row; emit every position when requested.
+            batch.logits[j] = (all_positions || abs_pos == n_tok - 1) ? 1 : 0;
+        }
+
+        if (llama_decode(this->ctx, batch) != 0) {
+            GENIEX_LOG_ERROR("forward_logits: llama_decode failed");
+            rc = GENIEX_ERROR_LLM_GENERATION_FAILED;
+            break;
+        }
+
+        // Extract logits for this chunk before the next decode overwrites them.
+        for (int j = 0; j < n; j++) {
+            if (!batch.logits[j]) continue;
+            const float* row = llama_get_logits_ith(this->ctx, j);
+            if (!row) {
+                rc = GENIEX_ERROR_LLM_GENERATION_FAILED;
+                break;
+            }
+            all_logits.insert(all_logits.end(), row, row + n_vocab);
+        }
+        if (rc != GENIEX_SUCCESS) break;
+    }
+    llama_batch_free(batch);
+
+    // Leave the KV cache clean regardless of outcome.
+    this->reset();
+
+    if (rc != GENIEX_SUCCESS) return rc;
+
+    // malloc so the caller can release with geniex_free() (which calls free()).
+    float* buf = static_cast<float*>(malloc(all_logits.size() * sizeof(float)));
+    if (!buf) return GENIEX_ERROR_COMMON_MEMORY_ALLOCATION;
+    memcpy(buf, all_logits.data(), all_logits.size() * sizeof(float));
+
+    output->logits     = buf;
+    output->vocab_size = n_vocab;
+    output->n_rows     = all_positions ? n_tok : 1;
     return GENIEX_SUCCESS;
 }
 }  // namespace geniex

--- a/sdk/plugins/qairt/include/llm.h
+++ b/sdk/plugins/qairt/include/llm.h
@@ -36,6 +36,8 @@ class QairtLlm : public ILlm {
     virtual int32_t generate(const geniex_LlmGenerateInput*, geniex_LlmGenerateOutput*) override;
 
     virtual int32_t get_model_info(geniex_LlmModelInfo*) override;
+
+    virtual int32_t forward_logits(const geniex_LlmForwardLogitsInput*, geniex_LlmForwardLogitsOutput*) override;
 };
 
 }  // namespace geniex

--- a/sdk/plugins/qairt/src/llm.cpp
+++ b/sdk/plugins/qairt/src/llm.cpp
@@ -3,9 +3,11 @@
 
 #include "llm.h"
 
+#include <cstdlib>
 #include <cstring>
 #include <exception>
 #include <filesystem>
+#include <stdexcept>
 #include <string>
 #include <utility>
 #include <vector>
@@ -298,6 +300,38 @@ int32_t QairtLlm::get_model_info(geniex_LlmModelInfo* output) {
     output->vocab_size = static_cast<int32_t>(vocab_size);
     output->bos_token  = pipeline_->bosTokenId();
     output->add_bos    = output->bos_token >= 0 ? 1 : 0;
+    return GENIEX_SUCCESS;
+}
+
+int32_t QairtLlm::forward_logits(const geniex_LlmForwardLogitsInput* input, geniex_LlmForwardLogitsOutput* output) {
+    if (!pipeline_) return GENIEX_ERROR_COMMON_NOT_INITIALIZED;
+    if (!input || !output) return GENIEX_ERROR_COMMON_INVALID_INPUT;
+    if (!input->input_ids || input->input_ids_count <= 0) return GENIEX_ERROR_COMMON_INVALID_INPUT;
+
+    std::vector<int32_t> input_ids(input->input_ids, input->input_ids + input->input_ids_count);
+
+    std::vector<float> logits;
+    try {
+        logits = pipeline_->forwardLogits(input_ids, input->all_positions);
+    } catch (const ContextLengthExceededError& e) {
+        GENIEX_LOG_WARN("QAIRT forward_logits: context length exceeded: {}", e.what());
+        return GENIEX_ERROR_LLM_TOKENIZATION_CONTEXT_LENGTH;
+    } catch (const std::invalid_argument& e) {
+        GENIEX_LOG_ERROR("QAIRT forward_logits: invalid input: {}", e.what());
+        return GENIEX_ERROR_COMMON_INVALID_INPUT;
+    }
+
+    const size_t vocab_size = pipeline_->vocabSize();
+    if (vocab_size == 0 || logits.empty()) return GENIEX_ERROR_LLM_GENERATION_FAILED;
+
+    // malloc so the caller can release with geniex_free() (which calls free()).
+    float* buf = static_cast<float*>(std::malloc(logits.size() * sizeof(float)));
+    if (!buf) return GENIEX_ERROR_COMMON_MEMORY_ALLOCATION;
+    std::memcpy(buf, logits.data(), logits.size() * sizeof(float));
+
+    output->logits     = buf;
+    output->vocab_size = static_cast<int32_t>(vocab_size);
+    output->n_rows     = static_cast<int32_t>(logits.size() / vocab_size);
     return GENIEX_SUCCESS;
 }
 

--- a/sdk/src/llm.cpp
+++ b/sdk/src/llm.cpp
@@ -1,8 +1,11 @@
 // Copyright (c) 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: BSD-3-Clause
 
+#include <algorithm>
+#include <cstdlib>
 #include <cstring>
 #include <memory>
+#include <vector>
 
 #include "geniex.h"
 #include "logging.h"
@@ -168,6 +171,80 @@ int32_t geniex_llm_get_model_info(geniex_LLM* h, geniex_LlmModelInfo* output) {
         return backend->get_model_info(output);
     } catch (const std::exception& e) {
         GENIEX_LOG_ERROR("llm get_model_info error: {}", e.what());
+        return GENIEX_ERROR_COMMON_UNKNOWN;
+    }
+}
+
+// Reduce full-vocab row-major logits to the top-N per row (descending logit),
+// writing new logits/token_ids buffers. Selection mirrors the O(vocab * top_n)
+// partial scan the benchmark used before this moved into the SDK. Frees the
+// plugin's full-vocab buffer and repoints output at the reduced buffers.
+static int32_t reduce_forward_logits_top_n(geniex_LlmForwardLogitsOutput* output, int32_t top_n) {
+    const int32_t n_rows     = output->n_rows;
+    const int32_t vocab_size = output->vocab_size;
+    const int32_t row_width  = top_n < vocab_size ? top_n : vocab_size;
+
+    float*            red_logits = static_cast<float*>(std::malloc((size_t)n_rows * row_width * sizeof(float)));
+    int32_t*          red_ids    = static_cast<int32_t*>(std::malloc((size_t)n_rows * row_width * sizeof(int32_t)));
+    std::vector<char> taken(vocab_size);
+    if (!red_logits || !red_ids) {
+        std::free(red_logits);
+        std::free(red_ids);
+        return GENIEX_ERROR_COMMON_MEMORY_ALLOCATION;
+    }
+
+    for (int32_t r = 0; r < n_rows; ++r) {
+        const float* row = output->logits + (size_t)r * vocab_size;
+        std::fill(taken.begin(), taken.end(), 0);
+        for (int32_t k = 0; k < row_width; ++k) {
+            int32_t best = -1;
+            for (int32_t v = 0; v < vocab_size; ++v) {
+                if (taken[v]) continue;
+                if (best < 0 || row[v] > row[best]) best = v;
+            }
+            taken[best]                           = 1;
+            red_logits[(size_t)r * row_width + k] = row[best];
+            red_ids[(size_t)r * row_width + k]    = best;
+        }
+    }
+
+    std::free(output->logits);
+    output->logits    = red_logits;
+    output->token_ids = red_ids;
+    output->row_width = row_width;
+    return GENIEX_SUCCESS;
+}
+
+int32_t geniex_llm_forward_logits(
+    geniex_LLM* h, const geniex_LlmForwardLogitsInput* input, geniex_LlmForwardLogitsOutput* output) {
+    GENIEX_LOG_TRACE("llm forward_logits");
+
+    if (!input || !output) return GENIEX_ERROR_COMMON_INVALID_INPUT;
+    if (!input->input_ids || input->input_ids_count <= 0) return GENIEX_ERROR_COMMON_INVALID_INPUT;
+    if (input->top_n < 0) return GENIEX_ERROR_COMMON_INVALID_INPUT;
+    std::memset(output, 0, sizeof(*output));
+
+    // No UTF-8 callback wrapping here: this path returns raw floats, not decoded text.
+    try {
+        auto backend = reinterpret_cast<ILlm*>(h);
+        if (!backend) return GENIEX_ERROR_COMMON_NOT_INITIALIZED;
+
+        // Plugins always produce full-vocab logits; the bridge does the top-N
+        // reduction so both backends share one implementation.
+        int32_t rc = backend->forward_logits(input, output);
+        if (rc != GENIEX_SUCCESS) return rc;
+
+        output->row_width = output->vocab_size;
+        if (input->top_n > 0 && output->vocab_size > 0) {
+            rc = reduce_forward_logits_top_n(output, input->top_n);
+            if (rc != GENIEX_SUCCESS) {
+                std::free(output->logits);
+                std::memset(output, 0, sizeof(*output));
+            }
+        }
+        return rc;
+    } catch (const std::exception& e) {
+        GENIEX_LOG_ERROR("llm forward_logits error: {}", e.what());
         return GENIEX_ERROR_COMMON_UNKNOWN;
     }
 }


### PR DESCRIPTION
## Summary

Adds a prefill-only forward pass that returns raw LM-head logits, so on-target accuracy metrics (perplexity, MMLU, MMMU) can be built on top of geniex instead of relying only on the generative metric. Wires it through both backends, both consumers, and the FFI bindings.

- **C API** — new `geniex_llm_forward_logits(handle, input, output)`: pre-tokenized `input_ids` + `all_positions` flag → row-major `[n_rows, vocab_size]` floats (last-token row, or every position). `ILlm` gains a `forward_logits` virtual defaulting to `PARAM_NOT_SUPPORTED`, mirroring `get_model_info`.
- **QAIRT backend** — wraps `LLMPipeline::forwardLogits`. Submodule `third-party/geniex-qairt` bumped to the merge of `geniex-qairt-plugin#23` (which exposes it).
- **llama.cpp backend** — builds an explicit batch with per-position logits flags and reads `llama_get_logits_ith`, on a **fresh KV cache** (reset on entry/exit) so `generate()`'s KV/prefix-cache state is untouched.
- **geniex-bench** — `--logits` / `--logits-all-positions` / `--logits-top-n` (default 20) run one forward pass over `-p N` random ids and write top-N `(token_id, logit)` pairs to the JSON report, recording the truncation.
- **geniex serve** — new `POST /v1/logits` (dedicated endpoint, not OpenAI generative logprobs semantics; documented in the OpenAPI spec).
- **Bindings** — Go `LLM.ForwardLogits`, Python ctypes + `modeling.forward_logits`.

### Note on Android JNI
`geniex.h` is a public header, so the FFI rule applies. JNI is intentionally **not** updated: it wraps only `create/destroy/generate/reset/apply_chat_template` and already omits `get_model_info`, and it links `libgeniex` directly (no `dlsym`), so a new additive C export cannot crash it at load. No Java/Kotlin consumer exists for this API.

## Test plan

- [x] SDK builds on `local` (Vulkan) and `qcs` (Windows/Snapdragon, Hexagon toolchain); `geniex_llm_forward_logits` exported from `libgeniex`.
- [x] CLI (`bazelisk`), Go bindings, and server packages build; gazelle-updated `BUILD.bazel`.
- [x] `geniex-bench --logits` on **llama.cpp** (local) and **QAIRT** (qcs, `qualcomm/Qwen3-4B-Instruct-2507`) — both emit top-N logits JSON.
- [x] **Correctness invariant** (both backends, both bench + serve): `all_positions=true` last row is byte-identical to the `all_positions=false` single row.
- [x] **Shape**: `all_positions=true` returns exactly `n_rows × vocab_size` floats.
- [x] **KV isolation**: a `/chat/completions` request after `/v1/logits` returns a clean, coherent generation (forward_logits left the KV cache clean).
- [x] `clang-format-18`, `ruff`, `gofmt`, `go mod tidy` clean.
- [ ] Python / Android build legs in CI.

Implements qcom-ai-hub/geniex#1323 (issue lives in the `qcom-ai-hub/geniex` mirror; upstream primitive: qualcomm/geniex-qairt-plugin#23).