### PR TITLE
feat(qairt): Add Gemma 4 QAIRT support

### DIFF
--- a/sdk/plugins/qairt/include/qnn_runtime_utils.h
+++ b/sdk/plugins/qairt/include/qnn_runtime_utils.h
@@ -7,7 +7,6 @@
 #include <windows.h>
 #endif
 
-#include <algorithm>
 #include <cstdlib>
 #include <filesystem>
 #include <optional>
@@ -18,21 +17,9 @@
 
 namespace geniex::qairt::runtime {
 
-inline std::vector<std::string> collect_bin_files(const std::filesystem::path& dir) {
-    std::vector<std::string> bins;
-    if (!std::filesystem::exists(dir) || !std::filesystem::is_directory(dir)) {
-        return bins;
-    }
-
-    for (const auto& entry : std::filesystem::directory_iterator(dir)) {
-        if (entry.is_regular_file() && entry.path().extension() == ".bin") {
-            bins.push_back(entry.path().string());
-        }
-    }
-
-    std::sort(bins.begin(), bins.end());
-    return bins;
-}
+// NOTE: no `collect_bin_files()` helper here on purpose. Context-binary shards must
+// come from genie_config.json's `ctx-bins` via the core's `modelConfigFromDirectory()`,
+// never from a `*.bin` glob: bundles also ship CPU-side payloads as `.bin`.
 
 inline std::optional<std::string> find_optional_file(const std::filesystem::path& dir, const char* filename) {
     const auto file_path = dir / filename;

--- a/sdk/plugins/qairt/src/llm.cpp
+++ b/sdk/plugins/qairt/src/llm.cpp
@@ -63,24 +63,24 @@ int32_t QairtLlm::create(const geniex_LlmCreateInput* input) {
 
     QnnRuntimeConfig runtime_cfg = qairt::runtime::make_qnn_runtime_config(model_dir);
 
-    // Discover .bin model shards
-    auto bin_shards = qairt::runtime::collect_bin_files(model_dir);
-    if (bin_shards.empty()) {
-        GENIEX_LOG_ERROR("No .bin model shards found in: {}", model_dir.string());
+    // Bundle layout comes from the QAIRT core: `modelConfigFromDirectory` reads
+    // genie_config.json's `dialog.engine.model.binary.ctx-bins` and takes only
+    // those files, in order, as context-binary shards. Do not glob `*.bin` —
+    // bundles also ship CPU-side payloads as `.bin` (e.g. Gemma4's embedding
+    // LUTs), which QNN cannot deserialize as context binaries.
+    ModelConfig model_cfg{};
+    try {
+        model_cfg = modelConfigFromDirectory(model_dir);
+    } catch (const std::exception& e) {
+        GENIEX_LOG_ERROR("Failed to resolve QAIRT bundle layout in {}: {}", model_dir.string(), e.what());
         return GENIEX_ERROR_COMMON_FILE_NOT_FOUND;
     }
 
-    GENIEX_LOG_DEBUG("Found {} model shards in {}", bin_shards.size(), model_dir.string());
+    GENIEX_LOG_DEBUG("Found {} model shards in {}", model_cfg.model_paths.size(), model_dir.string());
 
-    // Build ModelConfig
-    ModelConfig model_cfg{};
-    model_cfg.model_paths = std::move(bin_shards);
-
-    // Tokenizer path
+    // Tokenizer path: an explicit caller override wins over the bundle's own.
     if (input->tokenizer_path && input->tokenizer_path[0] != '\0') {
         model_cfg.tokenizer_path = input->tokenizer_path;
-    } else {
-        model_cfg.tokenizer_path = qairt::runtime::find_optional_file(model_dir, "tokenizer.json").value_or("");
     }
     if (model_cfg.tokenizer_path.empty()) {
         GENIEX_LOG_ERROR("tokenizer.json not found in: {}", model_dir.string());
@@ -92,10 +92,6 @@ int32_t QairtLlm::create(const geniex_LlmCreateInput* input) {
     if (!model_cfg.embedding_path) {
         model_cfg.embedding_path = qairt::runtime::find_optional_file(model_dir, "embed_tokens.npy");
     }
-
-    // HTP backend config
-    model_cfg.htp_config_path =
-        qairt::runtime::find_optional_file(model_dir, "htp_backend_ext_config.json").value_or("");
 
     // Forecast-prefix KV cache only needed for SSD models; non-SSD models leave this nullopt.
     model_cfg.forecast_prefix_path =

--- a/sdk/plugins/qairt/src/vlm.cpp
+++ b/sdk/plugins/qairt/src/vlm.cpp
@@ -71,32 +71,39 @@ int32_t QairtVlm::create(const geniex_VlmCreateInput* input) {
     }
 
     // ── LLM config ────────────────────────────────────────────────────────────
+    // Bundle layout comes from the core's `ctx-bins` handling, not a `*.bin` glob.
+    // See the note in llm.cpp.
     ModelConfig llm_cfg{};
-
-    auto bin_shards = qairt::runtime::collect_bin_files(model_dir);
-    if (!resolved_vision_bin.empty()) {
-        const fs::path vision_path(resolved_vision_bin);
-        bin_shards.erase(std::remove_if(bin_shards.begin(),
-                             bin_shards.end(),
-                             [&](const std::string& p) {
-                                 std::error_code ec;
-                                 if (fs::equivalent(fs::path(p), vision_path, ec)) return true;
-                                 return fs::path(p).filename() == vision_path.filename();
-                             }),
-            bin_shards.end());
+    try {
+        llm_cfg = modelConfigFromDirectory(model_dir);
+    } catch (const std::exception& e) {
+        GENIEX_LOG_ERROR("Failed to resolve QAIRT bundle layout in {}: {}", model_dir.string(), e.what());
+        return GENIEX_ERROR_COMMON_FILE_NOT_FOUND;
     }
-    if (bin_shards.empty()) {
+
+    // The vision encoder is driven as its own graph, so keep it out of the LLM
+    // shard list even if ctx-bins lists it.
+    if (!resolved_vision_bin.empty()) {
+        auto&          shards = llm_cfg.model_paths;
+        const fs::path vision_path(resolved_vision_bin);
+        shards.erase(std::remove_if(shards.begin(),
+                         shards.end(),
+                         [&](const std::string& p) {
+                             std::error_code ec;
+                             if (fs::equivalent(fs::path(p), vision_path, ec)) return true;
+                             return fs::path(p).filename() == vision_path.filename();
+                         }),
+            shards.end());
+    }
+    if (llm_cfg.model_paths.empty()) {
         GENIEX_LOG_ERROR("No .bin LLM shards found in: {}", model_dir.string());
         return GENIEX_ERROR_COMMON_FILE_NOT_FOUND;
     }
-    GENIEX_LOG_DEBUG("Found {} LLM shards in {}", bin_shards.size(), model_dir.string());
-    llm_cfg.model_paths = std::move(bin_shards);
+    GENIEX_LOG_DEBUG("Found {} LLM shards in {}", llm_cfg.model_paths.size(), model_dir.string());
 
-    // Tokenizer
+    // Tokenizer: an explicit caller override wins over the bundle's own.
     if (input->tokenizer_path && input->tokenizer_path[0] != '\0') {
         llm_cfg.tokenizer_path = input->tokenizer_path;
-    } else {
-        llm_cfg.tokenizer_path = qairt::runtime::find_optional_file(model_dir, "tokenizer.json").value_or("");
     }
     if (llm_cfg.tokenizer_path.empty()) {
         GENIEX_LOG_ERROR("tokenizer.json not found in: {}", model_dir.string());
@@ -108,7 +115,7 @@ int32_t QairtVlm::create(const geniex_VlmCreateInput* input) {
     if (!llm_cfg.embedding_path) {
         llm_cfg.embedding_path = qairt::runtime::find_optional_file(model_dir, "embed_tokens.npy");
     }
-    llm_cfg.htp_config_path = qairt::runtime::find_optional_file(model_dir, "htp_backend_ext_config.json").value_or("");
+    // htp_config_path is already resolved by modelConfigFromDirectory.
 
     // ── Vision encoder config ─────────────────────────────────────────────────
     ModelConfig vision_cfg{};


### PR DESCRIPTION
## Summary

Makes `geniex-bench` work end-to-end against a local AI Hub **Gemma 4 E2B** QAIRT bundle. Two independent bugs blocked it; both had to be fixed.

Nothing caught either one earlier because the standalone `gemma4_e2b` example builds its pipeline directly and bypasses both code paths. `geniex-bench` is the first consumer to drive a real Gemma 4 bundle through the plugin + dispatcher.

## 1. `*.bin` glob misidentified embedding LUTs as context binaries

`QairtLlm::create` / `QairtVlm::create` discovered context binaries by globbing every `*.bin` in the bundle directory. A Gemma 4 E2B bundle ships two CPU-side embedding lookup tables as `.bin` next to the one real context binary:

| file | size | is a context binary? |
| --- | --- | --- |
| `embed_token_int16_lut.bin` | 4.70 GB | no - CPU-side LUT |
| `embedding_int16_lut.bin` | 805 MB | no - CPU-side LUT |
| `part1_of_1.bin` | - | **yes** |

Sorted lexicographically, the 4.7 GB LUT landed at index 0, so QNN tried to deserialize it as a context binary:

```
Found 3 model shards in ...\gemma4_e2b_new
Failed to get context binary info for context index = 0
Failed to map context Binary for contextIdx: 0
Create From Binary FAILED!
geniex_llm_create: Model loading failed (code=-100201)
```

Both plugins now call the QAIRT core's `modelConfigFromDirectory()`, which reads `dialog.engine.model.binary.ctx-bins` out of `genie_config.json` and takes only those files, in the declared order. This keeps bundle-layout knowledge in the core instead of duplicating it in the plugin - the same principle the compute-unit alias table follows in `sdk/src/device.cpp`.

`collect_bin_files()` is deleted outright so the glob cannot be reintroduced.

Because `modelConfigFromDirectory` also resolves `tokenizer_path` and `htp_config_path`, the plugin's own probes for those are gone and a caller-supplied `tokenizer_path` now acts as an *override* of the bundle default rather than the only source.

## 2. Dispatcher did not match AI Hub's `model_id` spelling

Fixed in **qualcomm/geniex-qairt-plugin#24**, already merged; this PR bumps the submodule to `abf961f` to pick it up.

AI Hub exports Gemma 4 with `model_id = gemma_4_e2b_it` (mirroring the HF repo id `gemma-4-E2B-it`), but `models/dispatch.h` only matched the compact `gemma4_` spelling:

```
dispatch: no LLM factory matches model_id 'gemma_4_e2b_it'
```

Worth knowing for future families: the `model_id` prefix and the namespace are deliberately **two different naming systems** and are not expected to match. `gemma_4_* -> gemma4::` has exactly the same shape as the existing `falcon_v3_* -> falcon3::` and `llama_v3_* -> llama3::`. The compact spelling must never be used as a match prefix - no bundle declares it. #24 documents this in the dispatch header.

## Verification

Local `arm64-windows-snapdragon-release` build on an X Elite laptop, `geniex-bench` against on-disk bundles.

**Gemma 4 E2B (w4a16)** - previously could not load at all:

```
[DEBUG] llm.cpp:79:create] Found 1 model shards in ...\gemma4_e2b_new
[gen ] Gravity is a fundamental force of nature that attracts masses to each other...
[ok  ] plugin=qairt device=npu(id=NPU) ngl=0 ttft=134.1ms prefill=954.4tps decode=29.2tps gen=32 tok
```

**Llama 3.2 3B Instruct** - regression check, still loads and generates:

```
[DEBUG] llm.cpp:79:create] Found 3 model shards in ...\llama_v3_2_3b_instruct
[ok  ] plugin=qairt device=npu(id=NPU) ngl=0 ttft=275.9ms decode=7.6tps
```

That bundle holds 6 `.bin` files but declares 3 in `ctx-bins`, because it stages two complete quantization variants side by side. Shard count goes 6 -> 3; only the declared set now reaches QNN. The old glob happened to order the correct three first and merely appended three superfluous shards, so this was not a silent-corruption bug - but the extras were being handed to QNN for no reason.

## Not covered

- **Gemma 4 E4B is unverified.** No E4B bundle exists locally, and `models/gemma4/bundle-templates/README.md` marks `genie_config.e4b.json` as an untested template with no binaries. The `gemma_4_` prefix is variant-agnostic so E4B *should* route, but I have not run it.
- Vision path (`vlm.cpp`) compiles and got the same treatment, but was not exercised against a Gemma 4 VLM bundle.
- Prefill tps reported by the bench (~954) is higher than `ProfileData`'s `prefill_speed` (~186) because QAIRT pads the 25-token prompt to the 128 chunk and the bench reports padded work. Pre-existing and intentional - see #1194.

## Notes for reviewers

- `<algorithm>` was dropped from `qnn_runtime_utils.h` since the deleted `std::sort` was its only user; `<vector>` stays (still needed for `env_buffer`).
- `find_optional_file()` and `make_qnn_runtime_config()` are untouched and still in use.
