### PR TITLE
fix(sdk): key QAIRT ModelFile by precision so name:precision ids resolve

### DIFF
--- a/sdk/model-manager/crates/core/src/manifest.rs
+++ b/sdk/model-manager/crates/core/src/manifest.rs
@@ -56,6 +56,7 @@ pub struct ModelManifest {
     pub model_type: ModelType,
     #[serde(rename = "PluginId")]
     pub plugin_id: String,
+    /// DEPRECATED #1242: read-only compat for old QAIRT manifests; new ones key `ModelFile` by precision directly.
     #[serde(
         rename = "Precision",
         default,

--- a/sdk/model-manager/crates/core/src/source/ai_hub/mod.rs
+++ b/sdk/model-manager/crates/core/src/source/ai_hub/mod.rs
@@ -284,7 +284,7 @@ impl ModelSource for AiHubSource {
         let flat_entries = prepare_flat_entries(&raw_entries)?;
 
         // Lex-first `.bin` matches the Go CLI's `ExtractFlat`.
-        let (model_file, extra_files) = super::split_entrypoint_and_extras(
+        let (mut model_file, extra_files) = super::split_entrypoint_and_extras(
             &flat_entries,
             || "no .bin shard in archive".to_string(),
             |e| e.uncompressed_size as i64,
@@ -295,6 +295,13 @@ impl ModelSource for AiHubSource {
             .strip_prefix("PRECISION_")
             .unwrap_or(&asset.precision)
             .to_string();
+
+        // Key by real precision so /v1/models ids round-trip to /v1/chat/completions (#1242).
+        if !precision_label.is_empty() {
+            if let Some(entry) = model_file.remove("N/A") {
+                model_file.insert(precision_label.clone(), entry);
+            }
+        }
 
         // `domain` alone can't distinguish Qwen2.5-VL from text-only LLMs
         // (both report MODEL_DOMAIN_GENERATIVE_AI), so we also read the
@@ -311,7 +318,7 @@ impl ModelSource for AiHubSource {
             },
             model_type,
             plugin_id: "qairt".to_string(),
-            precision: precision_label,
+            precision: String::new(),
             model_file,
             mmproj_file: ModelFileInfo::default(),
             tokenizer_file: ModelFileInfo::default(),

--- a/sdk/model-manager/crates/core/src/store.rs
+++ b/sdk/model-manager/crates/core/src/store.rs
@@ -325,7 +325,27 @@ fn read_manifest(path: &std::path::Path) -> Result<ModelManifest> {
     let mut reader = file.take(MANIFEST_MAX_BYTES);
     let mut data = String::new();
     reader.read_to_string(&mut data)?;
-    Ok(serde_json::from_str(&data)?)
+    let mut manifest: ModelManifest = serde_json::from_str(&data)?;
+    if migrate_legacy_qairt_precision(&mut manifest) {
+        if let Ok(rewritten) = serde_json::to_string(&manifest) {
+            let _ = fs::write(path, rewritten);
+        }
+    }
+    Ok(manifest)
+}
+
+// DEPRECATED-COMPAT #1242: rewrite pre-fix QAIRT shape ("N/A" key + top-level Precision) to the new shape.
+fn migrate_legacy_qairt_precision(m: &mut ModelManifest) -> bool {
+    if m.plugin_id != "qairt" || m.precision.is_empty() {
+        return false;
+    }
+    if m.model_file.len() != 1 || !m.model_file.contains_key("N/A") {
+        return false;
+    }
+    let entry = m.model_file.remove("N/A").unwrap();
+    let key = std::mem::take(&mut m.precision);
+    m.model_file.insert(key, entry);
+    true
 }
 
 /// Split "org/repo:quant" into ("org/repo", Some("quant")) or ("org/repo", None).
@@ -546,5 +566,31 @@ mod tests {
         fs::write(dir.join(MANIFEST_FILE), big).unwrap();
         // Size-capped reader will truncate, then JSON parse fails — either way, Err.
         assert!(store.get_manifest("Org/Huge").is_err());
+    }
+
+    #[test]
+    fn legacy_qairt_manifest_migrates_on_read_and_rewrites_disk() {
+        let store = make_store();
+        let dir = store.cfg.model_dir("qualcomm/Legacy");
+        fs::create_dir_all(&dir).unwrap();
+        let legacy = r#"{
+            "Name":"qualcomm/Legacy","ModelName":"legacy","ModelType":"llm",
+            "PluginId":"qairt","Precision":"W4A16",
+            "ModelFile":{"N/A":{"Name":"model-00.bin","Downloaded":true,"Size":10}},
+            "MMProjFile":{"Name":"","Downloaded":false,"Size":0},
+            "TokenizerFile":{"Name":"","Downloaded":false,"Size":0},
+            "ExtraFiles":[]
+        }"#;
+        fs::write(dir.join(MANIFEST_FILE), legacy).unwrap();
+
+        let loaded = store.get_manifest("qualcomm/Legacy").unwrap();
+        assert_eq!(loaded.precision, "");
+        assert!(loaded.model_file.contains_key("W4A16"));
+        assert!(!loaded.model_file.contains_key("N/A"));
+
+        let on_disk = fs::read_to_string(dir.join(MANIFEST_FILE)).unwrap();
+        assert!(on_disk.contains(r#""W4A16":"#), "on-disk: {on_disk}");
+        assert!(!on_disk.contains(r#""N/A""#), "on-disk: {on_disk}");
+        assert!(!on_disk.contains(r#""Precision""#), "on-disk: {on_disk}");
     }
 }

--- a/sdk/model-manager/crates/core/tests/ai_hub_pull.rs
+++ b/sdk/model-manager/crates/core/tests/ai_hub_pull.rs
@@ -8,7 +8,7 @@
 //! a DEFLATE tokenizer. Confirms the resulting model directory matches
 //! what the Go CLI's `Store.PullZipAsset` would produce, *without the
 //! zip ever landing on disk*: entrypoint basename in
-//! `ModelFile["N/A"]`, extras populated, plugin_id = `"qairt"`.
+//! `ModelFile[<precision>]`, extras populated, plugin_id = `"qairt"`.
 
 use std::io::Write;
 use std::sync::Arc;
@@ -211,8 +211,8 @@ async fn ai_hub_pull_writes_manifest_and_extracts_flat() {
 
     let mf = store.get_manifest("tests/TestNet").unwrap();
     assert_eq!(mf.plugin_id, "qairt");
-    assert_eq!(mf.precision, "W4A16");
-    let entry = mf.model_file.get("N/A").expect("N/A quant entry");
+    assert_eq!(mf.precision, "");
+    let entry = mf.model_file.get("W4A16").expect("W4A16 quant entry");
     assert_eq!(entry.name, "model-00.bin");
     assert!(entry.downloaded);
     assert!(

--- a/sdk/model-manager/crates/core/tests/local_aihub_pull.rs
+++ b/sdk/model-manager/crates/core/tests/local_aihub_pull.rs
@@ -6,9 +6,9 @@
 //! Two flows are exercised: pulling from an already-extracted directory
 //! (lex-first `.bin` + metadata.json + extras), and pulling from a `.zip`
 //! containing a STORED `.bin` shard, a STORED `metadata.json`, and a
-//! DEFLATE tokenizer. The on-disk layout produced by either path must
-//! match what the AI Hub remote source produces: `model_file["N/A"]`
-//! holds the entrypoint basename, the rest go into `extra_files`, and
+//! DEFLATE tokenizer. Local pulls don't carry a precision label (no AI Hub
+//! asset metadata), so `model_file["N/A"]` holds the entrypoint basename
+//! as a placeholder, the rest go into `extra_files`, and
 //! `plugin_id == "qairt"`.
 
 use std::io::Write;

--- a/sdk/model-manager/crates/ffi/src/store.rs
+++ b/sdk/model-manager/crates/ffi/src/store.rs
@@ -183,23 +183,13 @@ pub extern "C" fn geniex_model_list_detailed(output: *mut GenieXModelListDetaile
         let details: Vec<GenieXModelDetail> = manifests
             .iter()
             .map(|m| {
-                // QAIRT manifests key model_file under "N/A" and carry the
-                // real precision (e.g. "W4A16") on the top-level field —
-                // surface that to bindings instead of the placeholder.
                 let downloaded: Vec<&str> = m
                     .model_file
                     .iter()
                     .filter(|(_, fi)| fi.downloaded)
                     .map(|(q, _)| q.as_str())
                     .collect();
-                let precs: Vec<*mut c_char> = if !m.precision.is_empty()
-                    && !downloaded.is_empty()
-                    && downloaded.iter().all(|q| *q == "N/A")
-                {
-                    vec![str_to_cptr(&m.precision)]
-                } else {
-                    downloaded.iter().map(|q| str_to_cptr(q)).collect()
-                };
+                let precs: Vec<*mut c_char> = downloaded.iter().map(|q| str_to_cptr(q)).collect();
                 let (precisions, precision_count) = into_c_array(precs);
                 GenieXModelDetail {
                     name: str_to_cptr(&m.name),


### PR DESCRIPTION
## Summary

QAIRT manifests kept the entrypoint under placeholder `"N/A"` and stored the real precision on a top-level `Precision` field. `/v1/models` advertised ids from the top-level (`qualcomm/Qwen3-4B-Instruct-2507:W4A16`), but the resolver only looked up `model_file` map keys directly — so any client that echoed the advertised id back to `/v1/chat/completions` (AnythingLLM auto-populates from `/v1/models`, for example) hit `quantization 'W4A16' not found`.

Root fix: key `model_file` by the precision label directly. AI Hub source has the real label (`W4A16`, `W8A16`, …); local AI Hub pulls have no such metadata, so they keep `"N/A"` as a real placeholder. The FFI escape hatch that surfaced the top-level `Precision` when the only key was `"N/A"` goes away. `resolve_model_paths` becomes a straight map lookup with no plugin-specific special casing.

Old on-disk manifests (`"N/A"` key + non-empty top-level `Precision`) are migrated transparently on read and rewritten to disk — no user action needed.

## Test plan

- [x] Snapdragon end-to-end: pull `qualcomm/Qwen3-4B-Instruct-2507` fresh, confirm on-disk manifest is `ModelFile["W4A16"]` with no top-level `Precision`
- [x] Snapdragon migration: three pre-existing QAIRT manifests on this host were in the old shape; a single `geniex list` rewrote all three on disk to the new shape

Closes #1242