### PR TITLE
feat(cli): show models cache root on list

### DIFF
--- a/cli/cmd/geniex/model.go
+++ b/cli/cmd/geniex/model.go
@@ -11,6 +11,7 @@ import (
 	"log/slog"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"slices"
 	"strconv"
 	"strings"
@@ -204,6 +205,8 @@ func list() *cobra.Command {
 		case "csv":
 			return printListCSV(models)
 		}
+		fmt.Println(render.GetTheme().Info.Sprintf("Models cached in %s", filepath.Join(store.Get().DataPath(), "models")))
+		fmt.Println()
 		printListTable(models, verbose)
 		return nil
 	}


### PR DESCRIPTION
## Pull Request

**Description**

One of the four UX items from the customer feedback report in #1295, split out from #1255. Output-side only; no SDK changes.

- `list --format=table` shows the models cache root as a header line.
- `--format json|csv` are unchanged.

The `pull` size/location/precision output was split into a separate PR (1271).

**Related Issue**

Refs qualcomm/GenieX#1295 (item 10). Split out from #1255.

**Type of Change**

- Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes