### PR TITLE
feat(cli/server): hint --host 0.0.0.0 when bound to loopback

### DIFF
--- a/cli/server/BUILD.bazel
+++ b/cli/server/BUILD.bazel
@@ -22,6 +22,8 @@ go_library(
 
 go_cgo_test(
     name = "server_test",
-    srcs = ["package_test.go"],
+    srcs = [
+        "server_test.go",
+    ],
     embed = [":server"],
 )

--- a/cli/server/package_test.go
+++ b/cli/server/package_test.go
@@ -1,8 +1,0 @@
-// Copyright (c) 2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-// SPDX-License-Identifier: BSD-3-Clause
-
-package server
-
-import "testing"
-
-func TestPackageBuilds(t *testing.T) {}

--- a/cli/server/server.go
+++ b/cli/server/server.go
@@ -5,7 +5,9 @@ package server
 
 import (
 	"fmt"
+	"net"
 	"os"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 
@@ -13,6 +15,23 @@ import (
 	"github.com/qualcomm/GenieX/cli/internal/render"
 	"github.com/qualcomm/GenieX/cli/server/service"
 )
+
+// hostBindingHint suggests --host 0.0.0.0 when bound to loopback, else "".
+// Malformed hosts are treated as non-loopback — better silent than misleading.
+func hostBindingHint(host string) string {
+	h, port, err := net.SplitHostPort(host)
+	if err != nil {
+		return ""
+	}
+	loopback := strings.EqualFold(h, "localhost")
+	if ip := net.ParseIP(h); ip != nil && ip.IsLoopback() {
+		loopback = true
+	}
+	if !loopback {
+		return ""
+	}
+	return fmt.Sprintf("Bound to loopback only. To expose on your network, restart with --host 0.0.0.0:%s", port)
+}
 
 // @Title		GenieX Server
 // @Version	0.0.0
@@ -48,9 +67,15 @@ func Serve() {
 
 		fmt.Println(render.GetTheme().Info.Sprintf("HTTPS enabled: cert=%s key=%s", certFile, keyFile))
 		fmt.Println(render.GetTheme().Info.Sprintf("Local hosting on https://%s/", cfg.Host))
+		if hint := hostBindingHint(cfg.Host); hint != "" {
+			fmt.Println(render.GetTheme().Info.Sprint(hint))
+		}
 		err = engine.RunTLS(cfg.Host, certFile, keyFile)
 	} else {
 		fmt.Println(render.GetTheme().Info.Sprintf("Local hosting on http://%s/", cfg.Host))
+		if hint := hostBindingHint(cfg.Host); hint != "" {
+			fmt.Println(render.GetTheme().Info.Sprint(hint))
+		}
 		err = engine.Run(cfg.Host)
 	}
 

--- a/cli/server/server_test.go
+++ b/cli/server/server_test.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
+package server
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestHostBindingHint(t *testing.T) {
+	tests := []struct {
+		name     string
+		host     string
+		wantHint bool
+		wantPort string // if wantHint, the port that should appear in the message
+	}{
+		{"ipv4 loopback", "127.0.0.1:18181", true, "18181"},
+		{"ipv4 loopback other subnet", "127.0.1.5:8080", true, "8080"},
+		{"localhost", "localhost:18181", true, "18181"},
+		{"localhost uppercase", "LOCALHOST:18181", true, "18181"},
+		{"ipv6 loopback", "[::1]:18181", true, "18181"},
+		{"any ipv4", "0.0.0.0:18181", false, ""},
+		{"any ipv6", "[::]:18181", false, ""},
+		{"lan ipv4", "192.168.1.10:18181", false, ""},
+		{"malformed no port", "127.0.0.1", false, ""},
+		{"empty", "", false, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := hostBindingHint(tt.host)
+			if tt.wantHint && got == "" {
+				t.Errorf("hostBindingHint(%q) = %q, want non-empty hint", tt.host, got)
+			}
+			if !tt.wantHint && got != "" {
+				t.Errorf("hostBindingHint(%q) = %q, want empty", tt.host, got)
+			}
+			if tt.wantHint && !strings.Contains(got, "--host 0.0.0.0:"+tt.wantPort) {
+				t.Errorf("hostBindingHint(%q) = %q, want it to suggest --host 0.0.0.0:%s", tt.host, got, tt.wantPort)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Pull Request

**Description**

One of the four UX items from the customer feedback report in #1295, split out from #1255. Output-side only; no SDK changes.

- `serve` prints a hint line when bound to a loopback address (127.0.0.0/8, `localhost`, `::1`), pointing users at `--host 0.0.0.0:<port>` to expose the server on the LAN.
- Non-loopback binds (0.0.0.0, [::], an explicit LAN IP) print nothing extra.
- Malformed hosts are treated as non-loopback — better silent than misleading.
- Replaces the placeholder `package_test.go` with `server_test.go` covering `hostBindingHint`.

**Related Issue**

Refs qualcomm/GenieX#1295 (item 5). Split out from #1255.

**Type of Change**

- Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

**Additional Context**

Verified manually on Windows ARM64 (Snapdragon X Elite): default bind printed the hint; `--host 0.0.0.0:18181` printed no hint; `[::1]:18181` printed the hint.