### PR TITLE
docs(release): add release check list and fix HTP file count

### DIFF
--- a/notes/release.md
+++ b/notes/release.md
@@ -165,12 +165,12 @@ The per-tag manifest is byte-stable across workflow re-runs of the same tag — 
 
 ## Hexagon HTP signing
 
-The Windows ARM64 SDK ships `libggml-htp.cat` plus `libggml-htp-v{68,69,73,75,79,81}.so` — Windows refuses to load them unsigned. Release CI runs an `overlay-htp` job **before** `build-cli` that sparse-checks-out `sdk/signed-htp/libggml-htp-<sha>.zip` from the `chore/signed-htp-lfs-store` branch of `qcom-ai-hub/geniex` (LFS-tracked), where `<sha>` is the `third-party/llama.cpp` short SHA. Both the installer and the SDK zip end up with the same HTP files:
+The Windows ARM64 SDK ships `libggml-htp.cat` plus `libggml-htp-v{73,75,79,81}.so` — Windows refuses to load them unsigned. Release CI runs an `overlay-htp` job **before** `build-cli` that sparse-checks-out `sdk/signed-htp/libggml-htp-<sha>.zip` from the `chore/signed-htp-lfs-store` branch of `qcom-ai-hub/geniex` (LFS-tracked), where `<sha>` is the `third-party/llama.cpp` short SHA. Both the installer and the SDK zip end up with the same HTP files:
 
 - **Hit** — overlay the Microsoft-signed files into the SDK artifact; `build-cli` packages them into the installer; release normally.
 - **Miss** — keep the self-signed build. The SDK name gets a `-selfsigned` suffix, and the release also carries `ggml-htp-v1.cer` (users import it) and `libggml-htp-to-sign-<sha>.zip` (operators submit it for signing).
 
-The signed bundle must contain exactly these eight files at the zip root: `libggml-htp.cat`, `libggml-htp.inf`, and `libggml-htp-v{68,69,73,75,79,81}.so`.
+The signed bundle must contain exactly these six files at the zip root: `libggml-htp.cat`, `libggml-htp.inf`, and `libggml-htp-v{73,75,79,81}.so`.
 
 The cross-repo checkout reuses `secrets.GH_PAT` (already scoped for cross-repo access to `qcom-ai-hub/geniex` — see `publish-s3` below). If CI reports `signed=false` but the bundle is on `chore/signed-htp-lfs-store`, first check that `GH_PAT` has not expired.
 
@@ -190,3 +190,19 @@ The cross-repo checkout reuses `secrets.GH_PAT` (already scoped for cross-repo a
 The Windows installer is published before it is Authenticode-signed, so `geniex update` gates on `windows-signed.txt` to avoid pushing an unsigned build. On Windows, once a newer version is found, the updater GETs this file (see [`cli/cmd/geniex/update.go`](../cli/cmd/geniex/update.go), `isWindowsSigned`): contents `true` → proceed with the download; anything else or missing → treat as up-to-date and skip.
 
 Release-side: upload `windows-signed.txt` with `true` after the latest stable installer is signed; set it back to a non-`true` value before publishing the next, not-yet-signed installer.
+
+# Check List
+
+- make sure `libggml-htp` is signed, if not, see [§ Hexagon HTP signing](#hexagon-htp-signing) above
+  - trigger an alpha version tag with `llama.cpp` bump up.
+  - follow [Promoting self-signed → Microsoft-signed](#promoting-self-signed--microsoft-signed)
+- trigger a rc version tag on `main`, and check below model
+  - `unsloth/Qwen3-0.6B-GGUF` and `unsloth/Qwen3.5-0.8B-GGUF` on `cpu` / `gpu` / `npu`
+  - `qualcomm/Qwen3-4B` and `qualcomm/Qwen3-VL-4B-Instruct`
+  - test `llama_cpp` npu on qualcomm pc
+- create a offical release tag on same commit
+- signed windows installer
+  - send unsigned installer to wido team
+  - replace installer on s3
+  - update sha256
+  - update `windows-signed.txt` to true, see [§ Windows installer signing gate](#windows-installer-signing-gate)


### PR DESCRIPTION
## What

- Add a **Check List** section to `notes/release.md` covering the end-to-end release procedure: HTP signing, rc-tag model smoke tests, official tag, and Windows installer signing.
- Fix a stale count in the Hexagon HTP signing section — the signed bundle now has **six** files (`cat`, `inf`, and `libggml-htp-v{73,75,79,81}.so`), not eight. The `.so` list had already dropped v68/v69.

## Why

Docs-only. Captures the release checklist so the steps aren't tribal knowledge, and corrects the file-count mismatch left over from trimming the HTP version list.