### PR TITLE
feat(cli): show size/location/precision on pull

### DIFF
--- a/cli/cmd/geniex/model.go
+++ b/cli/cmd/geniex/model.go
@@ -11,6 +11,7 @@ import (
 	"log/slog"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"slices"
 	"strconv"
 	"strings"
@@ -474,6 +475,25 @@ func pullModel(ctx context.Context, name string, quant string) error {
 	}
 
 	fmt.Println(render.GetTheme().Success.Sprint("✔  Download success"))
+
+	key := name
+	if quant != "" {
+		key = name + ":" + quant
+	}
+	if models, err := geniex_sdk.ModelListDetailed(); err == nil {
+		for _, m := range models {
+			if m.Name == name && m.TotalSize > 0 {
+				fmt.Println(render.GetTheme().Info.Sprintf("   Size:      %s", humanize.IBytes(uint64(m.TotalSize))))
+				break
+			}
+		}
+	}
+	if paths, err := geniex_sdk.ModelGetPaths(key); err == nil && paths.ModelPath != "" {
+		fmt.Println(render.GetTheme().Info.Sprintf("   Location:  %s", filepath.Dir(paths.ModelPath)))
+	}
+	if quant != "" {
+		fmt.Println(render.GetTheme().Info.Sprintf("   Precision: %s", quant))
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Pull Request

**Description**

One of the four UX items from the customer feedback report in #1295, split out from #1255 and #1263. Output-side only; no SDK changes.

- `pull` success prints the model's size / on-disk location / precision.

**Related Issue**

Refs qualcomm/GenieX#1295 (item 10). Split out from #1255; the `list` cache-root header lives in #1263.

**Type of Change**

- Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes

**Additional Context**

Size is sourced from `ModelListDetailed()` (the SDK has no single-model info API — `get_paths`/`get_type` don't return size); `pull` is a low-frequency operation so the one-time list walk is negligible.