### PR TITLE
fix(sdk): restore mtmd_input_text.text_len in VLM tokenize

### DIFF
--- a/sdk/plugins/llama_cpp/src/vlm.cpp
+++ b/sdk/plugins/llama_cpp/src/vlm.cpp
@@ -276,6 +276,7 @@ int32_t LlamaVlm::generate(const geniex_VlmGenerateInput* input, geniex_VlmGener
             // prompt_utf8 already has chat template and media markers applied
             mtmd_input_text text;
             text.text          = new_text_portion.c_str();
+            text.text_len      = new_text_portion.length();
             text.add_special   = this->n_past == 0;  // add BOS only on first message
             text.parse_special = true;
 


### PR DESCRIPTION
## Summary

2df324a8 accidentally dropped the `text.text_len` assignment that 0aa90fd3 added, leaving the field uninitialized. `mtmd_tokenize` reads `text_len` instead of `strlen(text)`, so every text-only VLM generate crashes: garbage `0` tokenizes an empty string → zero chunks → eval succeeds without decoding → first sample hits `GGML_ASSERT(logits != nullptr)` (sampling.cpp:154). This restores the assignment.

## Test plan

- [x] CPU repro (Qwen3.5-0.8B + mmproj, pinned submodule): `text_len=0` reproduces the exact #1269 assert; with it set, prefill and sampling work

Closes #1269
