### PR TITLE
feat(cli): print backend/device summary on infer --verbose

### DIFF
--- a/cli/cmd/geniex/BUILD.bazel
+++ b/cli/cmd/geniex/BUILD.bazel
@@ -43,6 +43,7 @@ go_library(
 go_cgo_test(
     name = "geniex_test",
     srcs = [
+        "infer_test.go",
         "model_test.go",
         "update_test.go",
     ],

--- a/cli/cmd/geniex/infer.go
+++ b/cli/cmd/geniex/infer.go
@@ -237,6 +237,23 @@ func loadStopSequences() ([]string, error) {
 	return stopSequences, nil
 }
 
+// modelLoadedLine formats a one-line summary of what the inference session
+// actually got, printed after the model is loaded when --verbose is set. It's
+// a pure helper so tests can pin the output without touching the SDK.
+func modelLoadedLine(runtimeID, deviceID string, ngl, nctx int32) string {
+	parts := []string{
+		fmt.Sprintf("backend=%s", runtimeID),
+		fmt.Sprintf("device=%s", deviceID),
+	}
+	if runtimeID == geniex_sdk.RuntimeLlamaCpp {
+		parts = append(parts,
+			fmt.Sprintf("ngl=%d", ngl),
+			fmt.Sprintf("nctx=%d", nctx),
+		)
+	}
+	return "Model loaded: " + strings.Join(parts, " ")
+}
+
 // resolveModelParams resolves --compute / --ngl / --nctx into the
 // (device_id, ngl, nctx) triple the SDK expects. --ngl (-1 = all) and
 // --nctx are llama_cpp-only; qairt rejects any non-zero value, so both
@@ -332,6 +349,10 @@ func inferLLM(ctx context.Context, paths *geniex_sdk.ModelPaths) error {
 		return err
 	}
 	defer p.Destroy()
+
+	if verbose {
+		fmt.Println(render.GetTheme().Info.Sprint(modelLoadedLine(paths.RuntimeID, deviceID, nglResolved, nctxResolved)))
+	}
 
 	var history []geniex_sdk.LlmChatMessage
 	if systemPrompt != "" {
@@ -488,6 +509,10 @@ func inferVLM(paths *geniex_sdk.ModelPaths) error {
 		return err
 	}
 	defer p.Destroy()
+
+	if verbose {
+		fmt.Println(render.GetTheme().Info.Sprint(modelLoadedLine(paths.RuntimeID, deviceID, nglResolved, nctxResolved)))
+	}
 
 	caps, _ := p.Capabilities()
 	slog.Debug("VLM capabilities", "vision", caps.SupportsVision, "audio", caps.SupportsAudio)

--- a/cli/cmd/geniex/infer_test.go
+++ b/cli/cmd/geniex/infer_test.go
@@ -1,0 +1,43 @@
+// Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
+package main
+
+import (
+	"testing"
+
+	geniex_sdk "github.com/qualcomm/GenieX/bindings/go"
+)
+
+func TestModelLoadedLine(t *testing.T) {
+	tests := []struct {
+		name              string
+		runtimeID, device string
+		ngl, nctx         int32
+		want              string
+	}{
+		{
+			name:      "llama_cpp shows ngl/nctx",
+			runtimeID: geniex_sdk.RuntimeLlamaCpp, device: "HTP0", ngl: 32, nctx: 4096,
+			want: "Model loaded: backend=llama_cpp device=HTP0 ngl=32 nctx=4096",
+		},
+		{
+			name:      "llama_cpp with ngl=-1 (all layers) still prints",
+			runtimeID: geniex_sdk.RuntimeLlamaCpp, device: "CPU", ngl: -1, nctx: 2048,
+			want: "Model loaded: backend=llama_cpp device=CPU ngl=-1 nctx=2048",
+		},
+		{
+			name:      "qairt hides ngl/nctx (not applicable)",
+			runtimeID: geniex_sdk.RuntimeQairt, device: "HTP0", ngl: 0, nctx: 0,
+			want: "Model loaded: backend=qairt device=HTP0",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := modelLoadedLine(tt.runtimeID, tt.device, tt.ngl, tt.nctx)
+			if got != tt.want {
+				t.Errorf("modelLoadedLine\n got: %q\nwant: %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Pull Request

**Description**

One of the four UX items from the customer feedback report in #1295, split out from #1255. Output-side only; no SDK changes.

- `infer --verbose` now prints a one-line summary of the resolved backend and device after the model is loaded.
- `ngl`/`nctx` are shown for `llama_cpp` and hidden for `qairt`.
- Extracted as a pure helper so tests can pin the output without touching the SDK.

**Related Issue**

Refs qualcomm/GenieX#1295 (item 4). Split out from #1255.

**Type of Change**

- Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes