### PR TITLE
fix(go): print only crashing goroutine on backend abort()

### DIFF
--- a/bindings/go/BUILD.bazel
+++ b/bindings/go/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
     name = "geniex_sdk_go",
     srcs = [
         "common.go",
+        "crash_handler.c",
         "device.go",
         "helpers.go",
         "llm.go",

--- a/bindings/go/crash_handler.c
+++ b/bindings/go/crash_handler.c
@@ -1,0 +1,78 @@
+// Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <string.h>
+
+// A library's abort() (failed assert, std::terminate, heap corruption) raises
+// SIGABRT. glibc's abort() force-resets the disposition and re-raises, so it
+// cannot be intercepted from Go via os/signal — the handler goroutine never
+// wins the race. A C signal handler runs synchronously in the aborting thread,
+// so it reliably replaces the runtime's dump of every goroutine's stack.
+//
+// The handler prints a short line, then calls back into Go to print only the
+// current goroutine's stack (runtime.Stack(buf, false)); chaining to the
+// runtime's own handler instead would force-print every goroutine, which
+// GOTRACEBACK cannot suppress on the cgo path.
+
+// Exported from Go (see ml.go): prints the current goroutine's stack.
+extern void go_dump_current(void);
+
+#ifdef _WIN32
+
+#include <io.h>       // _write
+#include <process.h>  // _exit
+#include <signal.h>
+#include <stdlib.h>
+
+static void geniex_fatal_handler(int sig) {
+    (void)sig;
+    static const char msg[] = "fatal: backend aborted (SIGABRT)\n";
+    _write(2, msg, (unsigned int)(sizeof(msg) - 1));
+    go_dump_current();
+    _exit(3);  // MSVCRT abort() convention
+}
+
+void geniex_install_crash_handler(void) {
+    // Suppress the "application error" dialog and Watson fault reporting;
+    // otherwise abort() blocks waiting for a human to dismiss it.
+    _set_abort_behavior(0, _WRITE_ABORT_MSG | _CALL_REPORTFAULT);
+    signal(SIGABRT, geniex_fatal_handler);
+    // SIGSEGV on Windows is an SEH exception, not reliably caught via signal();
+    // it would need SetUnhandledExceptionFilter, omitted here.
+}
+
+#else  // POSIX: Linux / Android / macOS
+
+#include <signal.h>
+#include <unistd.h>
+
+static void geniex_fatal_handler(int sig) {
+    const char* msg;
+    switch (sig) {
+        case SIGABRT:
+            msg = "fatal: backend aborted (SIGABRT)\n";
+            break;
+        case SIGSEGV:
+            msg = "fatal: backend segfault (SIGSEGV)\n";
+            break;
+        default:
+            msg = "fatal: backend crashed\n";
+            break;
+    }
+    ssize_t n = write(STDERR_FILENO, msg, strlen(msg));
+    (void)n;
+    go_dump_current();
+    _exit(134);  // 128 + SIGABRT
+}
+
+void geniex_install_crash_handler(void) {
+    struct sigaction sa;
+    memset(&sa, 0, sizeof(sa));
+    sa.sa_handler = geniex_fatal_handler;
+    sigemptyset(&sa.sa_mask);
+    sa.sa_flags = SA_RESETHAND;  // handle once, then restore default to avoid recursion
+    sigaction(SIGABRT, &sa, NULL);
+    sigaction(SIGSEGV, &sa, NULL);
+}
+
+#endif

--- a/bindings/go/ml.go
+++ b/bindings/go/ml.go
@@ -11,9 +11,13 @@ package geniex_sdk
 
 #if defined(_WIN32)
 __declspec(dllexport) void go_log_wrap(geniex_LogLevel level, char *msg);
+__declspec(dllexport) void go_dump_current(void);
 #else
 extern void go_log_wrap(geniex_LogLevel level, char *msg);
+extern void go_dump_current(void);
 #endif
+
+void geniex_install_crash_handler(void);
 */
 import "C"
 
@@ -21,6 +25,8 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"os"
+	"runtime"
 	"unsafe"
 )
 
@@ -57,6 +63,7 @@ var (
 
 // Init must be called before any other SDK function.
 func Init() error {
+	C.geniex_install_crash_handler()
 	res := C.geniex_init()
 	if res < 0 {
 		return SDKError(res)
@@ -206,6 +213,13 @@ func go_log_wrap(level C.geniex_LogLevel, msg *C.char) {
 	default:
 		slog.Debug(msgStr)
 	}
+}
+
+//export go_dump_current
+func go_dump_current() {
+	buf := make([]byte, 8192)
+	n := runtime.Stack(buf, false)
+	os.Stderr.Write(buf[:n])
 }
 
 // LCOV_EXCL_STOP


### PR DESCRIPTION
## Problem

A backend `abort()` (failed assert, `std::terminate`, heap corruption) raises `SIGABRT`. The Go runtime's fatal-signal handler dumps **every** goroutine's stack — 100+ lines of noise burying the actual crash site. On the cgo path this dump is emitted unconditionally: `GOTRACEBACK` / `debug.SetTraceback` cannot suppress it, and `os/signal` cannot intercept it (glibc's `abort()` force-resets the disposition and re-raises, so the handler goroutine never wins the race).

## Fix

Install a C signal handler for `SIGABRT` (and `SIGSEGV` on POSIX) from `Init()` — after the Go runtime has installed its own, so ours takes precedence. On a crash it:

1. writes one short line to stderr (`write`, async-signal-safe);
2. calls back into Go to print **only the crashing goroutine** via `runtime.Stack(buf, false)` — this is the goroutine holding the actual call chain;
3. `_exit`s.

Calling back into Go (rather than chaining to the runtime's original handler) is what makes single-goroutine output possible — chaining re-triggers the full multi-goroutine dump.

## Verification

End-to-end on a real CLI crash (Linux): output is the one-line message plus a single goroutine stack pointing straight at the crash site, exit code 134. Stress-tested the `runtime.Stack`-from-handler callback in three scenarios (crash on main goroutine, on a pure C thread, and under 50-goroutine lock contention), dozens of runs each — zero deadlocks.

## Notes

- `runtime.Stack` is not strictly async-signal-safe; stress testing showed it reliable in practice, but this is the one theoretical caveat.
- The Windows branch (`signal` + `_set_abort_behavior`) is written but **not verified on real hardware** — needs a check on qcs that the handler intercepts SDK-internal `abort()` (in particular that SDK and CLI link the same CRT).
- No `geniex.h` change — not an FFI change.